### PR TITLE
7.0 stock picking webkit

### DIFF
--- a/stock_picking_webkit/stock_view.xml
+++ b/stock_picking_webkit/stock_view.xml
@@ -4,6 +4,17 @@
         <record id="view_picking_out_form" model="ir.ui.view">
             <field name="name">stock.picking.out.form</field>
             <field name="model">stock.picking.out</field>
+            <field name="inherit_id" ref="stock.view_picking_out_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="/form/header//button[@string='Print Delivery Slip']" position="attributes">
+                    <attribute name="states">""</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_delivery_order_inherit_stock" model="ir.ui.view">
+            <field name="name">stock.picking.out.form</field>
+            <field name="model">stock.picking.out</field>
             <field name="inherit_id" ref="delivery.view_delivery_order_inherit_stock"/>
             <field name="arch" type="xml">
                 <xpath expr="/form/header//button[@string='Print Delivery Order' and @states='confirmed,assigned']" position="attributes">


### PR DESCRIPTION
Remove duplicated button for printing picking report.
Since this PR have been merged https://github.com/OCA/stock-logistics-reporting/pull/2 (I agree with it) when the picking is in the done state, odoo will show too button for printing the report (initialy this button print two different report but one is useless). I propose to hide on of this button to have a better experience for the user.
