### PR TITLE
[9.0][FIX] stock_valued_picking_report: Add ACL's for portal group

### DIFF
--- a/stock_valued_picking_report/__openerp__.py
+++ b/stock_valued_picking_report/__openerp__.py
@@ -8,7 +8,7 @@
 {
     "name": "Stock Valued Picking Report",
     "summary": "Adding Valued Picking on Delivery Slip report",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "website": "https://www.tecnativa.com",
@@ -21,6 +21,7 @@
         "delivery",
     ],
     "data": [
+        'security/ir.model.access.csv',
         'views/res_partner_view.xml',
         'report/stock_picking_valued_report.xml',
     ],

--- a/stock_valued_picking_report/security/ir.model.access.csv
+++ b/stock_valued_picking_report/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_move_operation_link_portal,stock.move.operation.link portal,stock.model_stock_move_operation_link,base.group_portal,1,0,0,0


### PR DESCRIPTION
Needed for portal users, without ACL they can't view computed values when the report is downloaded in website portal account.
cc @Tecnativa
