### PR TITLE
[FIX] stock_picking_report_valued: Remove round_method condition because don't apply here

### DIFF
--- a/stock_picking_report_valued/__manifest__.py
+++ b/stock_picking_report_valued/__manifest__.py
@@ -8,7 +8,7 @@
 {
     "name": "Valued Picking Report",
     "summary": "Adding Valued Picking on Delivery Slip report",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "website": "https://www.tecnativa.com",

--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -64,7 +64,8 @@ class StockMoveLine(models.Model):
         """
         for line in self:
             taxes = line.sale_tax_id.compute_all(
-                price_unit=line.sale_line.price_reduce,
+                price_unit=line.sale_line.price_subtotal / (
+                    line.sale_line.product_uom_qty or 0.0),
                 currency=line.currency_id,
                 quantity=line.qty_done or line.product_qty,
                 product=line.product_id,

--- a/stock_picking_report_valued/models/stock_picking.py
+++ b/stock_picking_report_valued/models/stock_picking.py
@@ -41,19 +41,11 @@ class StockPicking(models.Model):
         records...).
         """
         for pick in self:
-            sale = pick.sale_id
-            round_method = sale.company_id.tax_calculation_rounding_method
-            if round_method == 'round_globally':
-                amount_untaxed = sum(pick.move_line_ids.mapped(
-                    'sale_price_subtotal'))
-                amount_tax = sum(pick.move_line_ids.mapped(
-                    'sale_price_tax'))
-            else:
-                round_curr = sale.currency_id.round
-                amount_untaxed = amount_tax = 0.0
-                for tax_id, tax_group in pick.get_taxes_values().items():
-                    amount_untaxed += round_curr(tax_group['base'])
-                    amount_tax += round_curr(tax_group['amount'])
+            round_curr = pick.sale_id.currency_id.round
+            amount_untaxed = amount_tax = 0.0
+            for tax_id, tax_group in pick.get_taxes_values().items():
+                amount_untaxed += round_curr(tax_group['base'])
+                amount_tax += round_curr(tax_group['amount'])
             pick.update({
                 'amount_untaxed': amount_untaxed,
                 'amount_tax': amount_tax,


### PR DESCRIPTION
Never we can sum decimals of 2 distinct taxes and round after

round_method == 'round_globally'
base: 11.10   tax 4%: 0.444
base: 36.14  tax 10%: 3.614

Before this PR
Picking report totals > base: 47.24  taxes: 4.06  total: 51.30

After this PR
Picking report totals > base: 47.24  taxes: 4.05  total: 51.29

When invoice is created it shows always:
IVA 10% en 36,14 € 3,61 €
IVA 4% en 11,10 € 0,44 €

@Tecnativa