### PR TITLE
[FIX] stock_quantity_history_location: Wrong Dependency in stock_quantity_history_location

### DIFF
--- a/stock_quantity_history_location/__manifest__.py
+++ b/stock_quantity_history_location/__manifest__.py
@@ -11,7 +11,7 @@
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/stock-logistics-reporting',
     'depends': [
-        'stock',
+        'stock_account',
     ],
     'data': [
         'wizards/stock_quantity_history.xml',


### PR DESCRIPTION
Hello

This Pull request fix a bug on the valuation report  using the module stock_quantity_history_location.

Before  2f44e53 the direct module dependency was stock, this provoked that super call of open_table method of the wizard never executed.


I appreciate your support in advance.
