### PR TITLE
[FIX] Standard price incorrectly calculated on historic value

### DIFF
--- a/stock_inventory_valuation_report/reports/stock_inventory_valuation_report.py
+++ b/stock_inventory_valuation_report/reports/stock_inventory_valuation_report.py
@@ -53,14 +53,19 @@ class StockInventoryValuationReport(models.TransientModel):
                               create=False, edit=False))
         ReportLine = self.env['stock.inventory.valuation.view']
         for product in products:
+            standard_price = product.standard_price
+            if self.date:
+                standard_price = product.get_history_price(
+                    self.env.user.company_id.id,
+                    date=self.date)
             line = {
                 'display_name': product.display_name,
                 'qty_at_date': product.qty_at_date,
                 'uom_id': product.uom_id,
                 'currency_id': product.currency_id,
                 'cost_currency_id': product.cost_currency_id,
-                'standard_price': product.standard_price,
-                'stock_value': product.stock_value,
+                'standard_price': standard_price,
+                'stock_value': product.qty_at_date * standard_price,
                 'cost_method': product.cost_method,
             }
             if product.qty_at_date != 0:


### PR DESCRIPTION
When creating an historic inventory value export to XLS the current cost price of the product was used. This fix proposes using the historic cost price and changing the calculation of the value.

@ps-tubtim @rafaelbn 