### PR TITLE
[12.0][IMP] stock_inventory_valuation_report: Reference and Barcode columns

### DIFF
--- a/stock_inventory_valuation_report/i18n/stock_inventory_valuation_report.pot
+++ b/stock_inventory_valuation_report/i18n/stock_inventory_valuation_report.pot
@@ -210,3 +210,20 @@ msgstr ""
 msgid "report.s_i_v_r.report_stock_inventory_valuation_report_xlsx"
 msgstr ""
 
+#. module: stock_inventory_valuation_report
+#: model:ir.model.fields,field_description:stock_inventory_valuation_report.field_report_s_i_v_r_report_stock_inventory_valuation_report_xlsx__name
+#: model:ir.model.fields,field_description:stock_inventory_valuation_report.field_report_stock_inventory_valuation_report__name
+#: model:ir.model.fields,field_description:stock_inventory_valuation_report.field_stock_inventory_valuation_view__name
+#: model_terms:ir.ui.view,arch_db:stock_inventory_valuation_report.report_stock_inventory_valuation_lines_header
+msgid "Name"
+msgstr ""
+
+#. module: stock_inventory_valuation_report
+#: model:ir.model.fields,field_description:stock_inventory_valuation_report.field_stock_inventory_valuation_view__reference
+msgid "Reference"
+msgstr ""
+
+#. module: stock_inventory_valuation_report
+#: model:ir.model.fields,field_description:stock_inventory_valuation_report.field_stock_inventory_valuation_view__barcode
+msgid "Barcode"
+msgstr ""

--- a/stock_inventory_valuation_report/reports/stock_inventory_valuation_report.py
+++ b/stock_inventory_valuation_report/reports/stock_inventory_valuation_report.py
@@ -8,7 +8,9 @@ class StockInventoryValuationView(models.TransientModel):
     _name = 'stock.inventory.valuation.view'
     _description = 'Stock Inventory Valuation View'
 
-    display_name = fields.Char()
+    name = fields.Char()
+    reference = fields.Char()
+    barcode = fields.Char()
     qty_at_date = fields.Float()
     uom_id = fields.Many2one(
         comodel_name='uom.uom',
@@ -54,7 +56,9 @@ class StockInventoryValuationReport(models.TransientModel):
         ReportLine = self.env['stock.inventory.valuation.view']
         for product in products:
             line = {
-                'display_name': product.display_name,
+                'name': product.name,
+                'reference': product.default_code,
+                'barcode': product.barcode,
                 'qty_at_date': product.qty_at_date,
                 'uom_id': product.uom_id,
                 'currency_id': product.currency_id,

--- a/stock_inventory_valuation_report/reports/stock_inventory_valuation_report.xml
+++ b/stock_inventory_valuation_report/reports/stock_inventory_valuation_report.xml
@@ -99,7 +99,9 @@
         <div class="act_as_thead">
             <div class="act_as_row labels">
                 <div class="act_as_cell">#</div>
-                <div class="act_as_cell">Display Name</div>
+                <div class="act_as_cell">Reference</div>
+                <div class="act_as_cell">Name</div>
+                <div class="act_as_cell">Barcode</div>
                 <div class="act_as_cell">Quantity</div>
                 <div class="act_as_cell">Cost</div>
                 <div class="act_as_cell">Value</div>
@@ -113,7 +115,13 @@
                 <t t-esc="n"/>
             </div>
             <div class="act_as_cell left">
-                <t t-esc="line.display_name"/>
+                <t t-esc="line.reference"/>
+            </div>
+            <div class="act_as_cell left">
+                <t t-esc="line.name"/>
+            </div>
+            <div class="act_as_cell left">
+                <t t-esc="line.barcode"/>
             </div>
             <div class="act_as_cell right">
                 <t t-esc="'{0:,.3f}'.format(line.qty_at_date)"/>

--- a/stock_inventory_valuation_report/reports/stock_inventory_valuation_report_xlsx.py
+++ b/stock_inventory_valuation_report/reports/stock_inventory_valuation_report_xlsx.py
@@ -23,16 +23,34 @@ class ReportStockInventoryValuationReportXlsx(models.TransientModel):
                 },
                 'width': 12,
             },
-            '2_display_name': {
+            '2_reference': {
                 'header': {
-                    'value': 'Display Name',
+                    'value': 'Reference',
                 },
                 'data': {
-                    'value': self._render('display_name'),
+                    'value': self._render('reference'),
+                },
+                'width': 15,
+            },
+            '3_name': {
+                'header': {
+                    'value': 'Name',
+                },
+                'data': {
+                    'value': self._render('name'),
                 },
                 'width': 36,
             },
-            '3_qty_at_date': {
+            '4_barcode': {
+                'header': {
+                    'value': 'Barcode',
+                },
+                'data': {
+                    'value': self._render('barcode'),
+                },
+                'width': 15,
+            },
+            '5_qty_at_date': {
                 'header': {
                     'value': 'Quantity',
                 },
@@ -42,7 +60,7 @@ class ReportStockInventoryValuationReportXlsx(models.TransientModel):
                 },
                 'width': 18,
             },
-            '4_standard_price': {
+            '6_standard_price': {
                 'header': {
                     'value': 'Cost',
                 },
@@ -52,7 +70,7 @@ class ReportStockInventoryValuationReportXlsx(models.TransientModel):
                 },
                 'width': 18,
             },
-            '5_stock_value': {
+            '7_stock_value': {
                 'header': {
                     'value': 'Value',
                 },
@@ -109,7 +127,9 @@ class ReportStockInventoryValuationReportXlsx(models.TransientModel):
                     ws, row_pos, ws_params, col_specs_section='data',
                     render_space={
                         'n': row_pos-5,
-                        'display_name': line.display_name or '',
+                        'name': line.name or '',
+                        'reference': line.reference or '',
+                        'barcode': line.barcode or '',
                         'qty_at_date': line.qty_at_date or 0.000,
                         'standard_price': line.standard_price or 0.00,
                         'stock_value': line.stock_value or 0.00,
@@ -117,4 +137,4 @@ class ReportStockInventoryValuationReportXlsx(models.TransientModel):
                     default_format=self.format_tcell_left)
                 total += line.stock_value
 
-            ws.write(row_pos, 4, total, self.format_theader_blue_amount_right)
+            ws.write(row_pos, 6, total, self.format_theader_blue_amount_right)


### PR DESCRIPTION
It separates the reference and name into 2 columns (instead of showing the display name).
This is usually better for analysis, specially on the excel file.

It also adds the barcode to the report, which is usefull most of the times