### PR TITLE
[12.0][FIX] stock_card_report: display the correct product name

### DIFF
--- a/stock_card_report/reports/stock_card_report.xml
+++ b/stock_card_report/reports/stock_card_report.xml
@@ -54,7 +54,7 @@
         <t t-foreach="o.product_ids" t-as="product">
             <div class="page">
                 <div class="row">
-                    <t t-set="title">Stock Card - <t t-raw="product.name"/></t>
+                    <t t-set="title">Stock Card - <t t-raw="product.display_name"/></t>
                     <h4 class="mt0" t-esc="title" style="text-align: center;"/>
                 </div>
                 <!-- Display filters -->


### PR DESCRIPTION
If product variants are used, display the full variant name (with attributes) instead of the template name.
If not, this change doesn't affect the output.