### PR TITLE
[12.0][FIX] stock_picking_report_valued: Round computed price to avoid difference

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -1,10 +1,11 @@
 # Copyright 2014-2018 Tecnativa - Pedro M. Baeza
 # Copyright 2015 Antonio Espinosa - Tecnativa <antonio.espinosa@tecnativa.com>
 # Copyright 2018 Luis M. Ontalba - Tecnativa <luis.martinez@tecnativa.com>
-# Copyright 2016-2018 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
+# Copyright 2016-2021 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.tools.float_utils import float_round
 
 
 class StockMoveLine(models.Model):
@@ -57,11 +58,17 @@ class StockMoveLine(models.Model):
         access to sales orders (stricter warehouse users, inter-company
         records...).
         """
+        prec = self.env['decimal.precision'].precision_get('Product Price')
         for line in self:
             sale_line = line.sale_line
             price_unit = (
-                sale_line.price_subtotal / sale_line.product_uom_qty
-                if sale_line.product_uom_qty else sale_line.price_reduce)
+                float_round(
+                    sale_line.price_subtotal / sale_line.product_uom_qty,
+                    precision_digits=prec,
+                )
+                if sale_line.product_uom_qty
+                else sale_line.price_reduce
+            )
             taxes = line.sale_tax_id.compute_all(
                 price_unit=price_unit,
                 currency=line.currency_id,

--- a/stock_picking_report_valued/tests/test_stock_picking_valued.py
+++ b/stock_picking_report_valued/tests/test_stock_picking_valued.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Tecnativa - David Vidal
 # Copyright 2017 Tecnativa - Luis M. Ontalba
-# Copyright 2019 Tecnativa - Carlos Dauden
+# Copyright 2019-2021 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests import common
@@ -107,3 +107,16 @@ class TestStockPickingValued(common.SavepointCase):
             self.assertEqual(picking.amount_untaxed, 300.0)
             self.assertEqual(picking.amount_tax, 40.0)
             self.assertEqual(picking.amount_total, 340.0)
+
+    def test_05_partial_delivery_computed_price(self):
+        self.assertTrue(self.partner.valued_picking)
+        self.sale_order.order_line.price_unit = 23.45
+        self.sale_order.order_line.product_uom_qty = 3.72
+        self.sale_order.action_confirm()
+        self.assertTrue(len(self.sale_order.picking_ids))
+        for picking in self.sale_order.picking_ids:
+            picking.action_assign()
+            picking.move_line_ids.qty_done = 3.55
+            self.assertAlmostEqual(picking.amount_untaxed, 83.25, 2)
+            self.assertAlmostEqual(picking.amount_tax, 12.49, 2)
+            self.assertAlmostEqual(picking.amount_total, 95.74, 2)


### PR DESCRIPTION
 between picking and invoice.

Steps to reproduce:
- Create a sale line with qty = 3.72 and price = 23.45 
- Confirm Sale Order and click in delivery
- Fill qty done = 3.55
- Print valued delivery

Before this PR: 
subtotal = 83.24 (3.55 * 23.448924731182796)

After this PR:
subtotal = 83.25 (3.55 * 23.45)

@Tecnativa TT17492