### PR TITLE
[12.0][FIX] stock_account_quantity_history_location: Assumes qty_available …

### DIFF
--- a/stock_account_quantity_history_location/wizards/stock_quantity_history.py
+++ b/stock_account_quantity_history_location/wizards/stock_quantity_history.py
@@ -18,7 +18,10 @@ class StockQuantityHistory(models.TransientModel):
         # anomalies, such as, non 0 stock_value on cost_method FIFO
         if not self.location_id:
             domain = ast.literal_eval(action['domain'])
-            domain.pop(domain.index(('qty_available', '!=', 0)))
+            try:
+                domain.remove(('qty_available', '!=', 0))
+            except ValueError:
+                pass
             action['domain'] = domain
         ctx = action['context']
         if isinstance(ctx, str):


### PR DESCRIPTION
…filter is in domain, and fails if already removed by another module