### PR TITLE
[12.0][FIX] stock_inventory_valuation_report: show quantity in the past for currently not available products

### DIFF
--- a/stock_inventory_valuation_report/__manifest__.py
+++ b/stock_inventory_valuation_report/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Stock Inventory Valuation Report',
     'summary': 'Add report button on Inventory Valuation.',
-    'version': '12.0.1.1.1',
+    'version': '12.0.1.1.2',
     'category': 'Warehouse',
     'website': 'https://github.com/OCA/stock-logistics-reporting',
     'author': 'Ecosoft,Odoo Community Association (OCA)',

--- a/stock_inventory_valuation_report/reports/stock_inventory_valuation_report.py
+++ b/stock_inventory_valuation_report/reports/stock_inventory_valuation_report.py
@@ -50,9 +50,9 @@ class StockInventoryValuationReport(models.TransientModel):
         if not self.compute_at_date:
             self.date = fields.Datetime.now()
         products = self.env['product.product'].\
-            search([('type', '=', 'product'), ('qty_available', '!=', 0)]).\
             with_context(dict(to_date=self.date, company_owned=True,
-                              create=False, edit=False))
+                              create=False, edit=False)).\
+            search([('type', '=', 'product'), ('qty_available', '!=', 0)])
         ReportLine = self.env['stock.inventory.valuation.view']
         for product in products:
             standard_price = product.standard_price


### PR DESCRIPTION
Fix https://github.com/OCA/stock-logistics-reporting/issues/96.

**Steps to reproduce** (see also added test)

1. Create a new storable product
2. Create a receipt for **N** pieces of the product and validate it.
    Take note of the **date** when the product is available.
3. Create a delivery for **N** pieces of the product and validate it.
4. Open the wizard Inventory > Reporting > Inventory Valuation and select:
    - Compute = At Specific Date
    - Inventory at Date = **date**
5. Click on Export XLSX

**Before this PR**
XLSX report does not show the product

**After this PR**
XLSX report does show the product with quantity **N**