### PR TITLE
[FIX] stock_picking_report_valued_sale_mrp: ignored cancelled order

### DIFF
--- a/stock_picking_report_valued_sale_mrp/models/stock_move.py
+++ b/stock_picking_report_valued_sale_mrp/models/stock_move.py
@@ -17,5 +17,12 @@ class StockMove(models.Model):
         component_demand = sum(
             sale_line.move_ids.filtered(
                 lambda x: x.product_id == self.product_id and
-                not x.origin_returned_move_id).mapped("product_uom_qty"))
+                not x.origin_returned_move_id and
+                (
+                    x.state != "cancel" or (
+                        x.state == "cancel" and x.backorder_id
+                    )
+                )
+            ).mapped("product_uom_qty")
+        )
         return component_demand / sale_line.product_uom_qty


### PR DESCRIPTION
We want to consider backordered moves even if they're cancelled but not
cancelled moves from cancelled orders, that must be filtered. Otherwise,
they pullute the amounts computation.

cc @Tecnativa TT29363

please review @ernestotejeda @pedrobaeza 