### PR TITLE
[stock_report_quantity_by_location][imp] allow to report based on availability.

### DIFF
--- a/stock_report_quantity_by_location/wizards/stock_report_quantity_by_location_views.xml
+++ b/stock_report_quantity_by_location/wizards/stock_report_quantity_by_location_views.xml
@@ -14,6 +14,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
                         <field name="location_ids" widget="many2many_tags" />
                     </group>
                     <group>
+                        <field name="availability" />
                         <field name="with_quantity" />
                     </group>
                 </group>


### PR DESCRIPTION
New field 'availability' in the wizard, allowing you to report on
quantities on hand, or quantities unreserved (on hand - reservations).

![image](https://user-images.githubusercontent.com/7683926/117396008-68024100-aef9-11eb-8ef1-0bcf94345304.png)

@ForgeFlow