### PR TITLE
[13.0][ADD] 2 modules related to sale_order_line_position

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,24 @@ stages:
 
 jobs:
   include:
+    # Separate tests because the depence stock_picking_group_by_partner_by_carrier
+    # clashes with other module in the repository.
     - stage: test
       env:
         - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT="1"
+          INCLUDE="delivery_line_sale_line_position,stock_picking_group_by_partner_by_carrier_sale_line_position"
     - stage: test
       env:
         - TESTS=1 ODOO_REPO="OCA/OCB"
+          INCLUDE="delivery_line_sale_line_position,stock_picking_group_by_partner_by_carrier_sale_line_position"
+    - stage: test
+      env:
+        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT="1"
+          EXCLUDE="delivery_line_sale_line_position,stock_picking_group_by_partner_by_carrier_sale_line_position"
+    - stage: test
+      env:
+        - TESTS=1 ODOO_REPO="OCA/OCB"
+          EXCLUDE="delivery_line_sale_line_position,stock_picking_group_by_partner_by_carrier_sale_line_position"
 env:
   global:
     - VERSION="13.0" TESTS="0" LINT_CHECK="0" MAKEPOT="0"

--- a/delivery_line_sale_line_position/__init__.py
+++ b/delivery_line_sale_line_position/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_line_sale_line_position/__manifest__.py
+++ b/delivery_line_sale_line_position/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Delivery Line Sale Line Position",
+    "summary": "Adds the sale line position to the delivery report lines",
+    "version": "13.0.1.0.0",
+    "category": "Delivery",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/stock-logistics-reporting",
+    "depends": ["sale_order_line_position"],
+    "data": [
+        "report/report_deliveryslip.xml",
+        "views/stock_move.xml",
+        "views/stock_picking.xml",
+    ],
+    "installable": True,
+}

--- a/delivery_line_sale_line_position/models/__init__.py
+++ b/delivery_line_sale_line_position/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_move
+from . import stock_move_line

--- a/delivery_line_sale_line_position/models/stock_move.py
+++ b/delivery_line_sale_line_position/models/stock_move.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    position_sale_line = fields.Char(
+        related="sale_line_id.position_formatted", string="Position"
+    )

--- a/delivery_line_sale_line_position/models/stock_move_line.py
+++ b/delivery_line_sale_line_position/models/stock_move_line.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    position_sale_line = fields.Char(
+        related="move_id.position_sale_line", string="Position"
+    )

--- a/delivery_line_sale_line_position/readme/CONTRIBUTORS.rst
+++ b/delivery_line_sale_line_position/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/delivery_line_sale_line_position/readme/DESCRIPTION.rst
+++ b/delivery_line_sale_line_position/readme/DESCRIPTION.rst
@@ -1,0 +1,6 @@
+This module is build on top of the module `sale_order_line_position`.
+
+On the delivery report it adds a column with the `Postion` from the related
+sale order line.
+
+The `Position` can also made visible int the stock picking view.

--- a/delivery_line_sale_line_position/report/report_deliveryslip.xml
+++ b/delivery_line_sale_line_position/report/report_deliveryslip.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+  <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
+
+    <!-- Changes for when the picking is not yet done -->
+
+    <xpath expr="//table[@name='stock_move_table']/thead" position="before">
+      <t
+                t-set="has_line_position"
+                t-value="any(o.move_lines.filtered(lambda x: x.position_sale_line and x.product_uom_qty))"
+            />
+    </xpath>
+
+    <xpath expr="//th[@name='th_sm_product']" position="before">
+      <th t-if="has_line_position" name="th_sm_pos"><strong>Pos</strong></th>
+    </xpath>
+    <!-- The star in the selector may seem not very specific, but it is done -->
+    <!-- in purpose so it works with some other module that change this report. -->
+    <!-- Looking at you stock_picking_group_by_partner_by_carrier -->
+    <xpath expr="//table[@name='stock_move_table']/tbody/tr/*[1]" position="before">
+      <td t-if="has_line_position">
+        <span t-field="move.position_sale_line" />
+      </td>
+    </xpath>
+
+
+    <!-- Changes for when the picking is done -->
+
+    <xpath expr="//table[@name='stock_move_line_table']/thead" position="before">
+      <t
+                t-set="has_line_position"
+                t-value="any(o.move_line_ids.mapped('position_sale_line'))"
+            />
+    </xpath>
+
+    <xpath expr="//th[@name='th_sml_product']" position="before">
+      <th t-if="has_line_position" name="th_sml_pos"><strong>Pos</strong></th>
+    </xpath>
+    <xpath
+            expr="//table[@name='stock_move_line_table']/tbody/tr/*[1]"
+            position="before"
+        >
+      <td t-if="has_line_position">
+        <span t-field="move_line.move_id.position_sale_line" />
+      </td>
+    </xpath>
+
+  </template>
+</odoo>

--- a/delivery_line_sale_line_position/views/stock_move.xml
+++ b/delivery_line_sale_line_position/views/stock_move.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+  <record id="view_stock_move_line_detailed_operation_tree" model="ir.ui.view">
+    <field name="name">stock.move.line.operations.tree</field>
+    <field name="model">stock.move.line</field>
+    <field name="inherit_id" ref="stock.view_stock_move_line_detailed_operation_tree" />
+    <field name="arch" type="xml">
+
+      <xpath expr="//field[@name='product_id']" position="before">
+        <field name="position_sale_line" optional="hide" />
+      </xpath>
+
+    </field>
+  </record>
+
+</odoo>

--- a/delivery_line_sale_line_position/views/stock_picking.xml
+++ b/delivery_line_sale_line_position/views/stock_picking.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+  <record id="view_picking_form" model="ir.ui.view">
+    <field name="name">stock.view.picking.form</field>
+    <field name="model">stock.picking</field>
+    <field name="inherit_id" ref="stock.view_picking_form" />
+    <field name="arch" type="xml">
+
+      <xpath
+                expr="//field[@name='move_ids_without_package']/tree/field[@name='product_id']"
+                position="before"
+            >
+        <field name="position_sale_line" optional="hide" />
+      </xpath>
+
+    </field>
+  </record>
+
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,3 +1,4 @@
 # See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
 server-ux
 reporting-engine
+sale-reporting

--- a/setup/delivery_line_sale_line_position/odoo/addons/delivery_line_sale_line_position
+++ b/setup/delivery_line_sale_line_position/odoo/addons/delivery_line_sale_line_position
@@ -1,0 +1,1 @@
+../../../../delivery_line_sale_line_position

--- a/setup/delivery_line_sale_line_position/setup.py
+++ b/setup/delivery_line_sale_line_position/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/stock_picking_group_by_partner_by_carrier_sale_line_position/odoo/addons/stock_picking_group_by_partner_by_carrier_sale_line_position
+++ b/setup/stock_picking_group_by_partner_by_carrier_sale_line_position/odoo/addons/stock_picking_group_by_partner_by_carrier_sale_line_position
@@ -1,0 +1,1 @@
+../../../../stock_picking_group_by_partner_by_carrier_sale_line_position

--- a/setup/stock_picking_group_by_partner_by_carrier_sale_line_position/setup.py
+++ b/setup/stock_picking_group_by_partner_by_carrier_sale_line_position/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_picking_group_by_partner_by_carrier_sale_line_position/__init__.py
+++ b/stock_picking_group_by_partner_by_carrier_sale_line_position/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_group_by_partner_by_carrier_sale_line_position/__manifest__.py
+++ b/stock_picking_group_by_partner_by_carrier_sale_line_position/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Stock Picking Group By Partner By Carrier Sale Line Position",
+    "summary": "Glue module for sale position and delivery report grouped",
+    "version": "13.0.1.0.0",
+    "category": "Delivery",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/stock-logistics-reporting",
+    "depends": [
+        "delivery_line_sale_line_position",
+        "stock_picking_group_by_partner_by_carrier",
+    ],
+    "data": ["report/report_deliveryslip.xml"],
+    "installable": True,
+    "auto_install": True,
+}

--- a/stock_picking_group_by_partner_by_carrier_sale_line_position/models/__init__.py
+++ b/stock_picking_group_by_partner_by_carrier_sale_line_position/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/stock_picking_group_by_partner_by_carrier_sale_line_position/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier_sale_line_position/models/stock_picking.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _get_sorted_moves(self):
+        self.ensure_one()
+        return self.move_lines.sorted(
+            lambda m: m.sale_line_id.order_id.id * 1000 + m.sale_line_id.position
+        )
+
+    def _get_sorted_move_lines(self):
+        self.ensure_one()
+        return self.move_line_ids.sorted(lambda l: l.move_id.sale_line_id.position)

--- a/stock_picking_group_by_partner_by_carrier_sale_line_position/readme/CONTRIBUTORS.rst
+++ b/stock_picking_group_by_partner_by_carrier_sale_line_position/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/stock_picking_group_by_partner_by_carrier_sale_line_position/readme/DESCRIPTION.rst
+++ b/stock_picking_group_by_partner_by_carrier_sale_line_position/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This is a glue module for the sale line position on the delivery report
+and the module `stock_picking_group_by_partner_by_carrier`.
+
+It ensures that on the delivery report the position column is displayed
+only if some positions exist.
+And also adds the sale line position on the remaining to deliver list at
+the bottom of the report.

--- a/stock_picking_group_by_partner_by_carrier_sale_line_position/report/report_deliveryslip.xml
+++ b/stock_picking_group_by_partner_by_carrier_sale_line_position/report/report_deliveryslip.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+  <template
+        id="report_delivery_document"
+        inherit_id="delivery_line_sale_line_position.report_delivery_document"
+    >
+
+
+    <xpath
+            expr="//table[@name='stock_move_table']/t[@t-set='has_line_position']"
+            position="attributes"
+        >
+      <attribute
+                name="t-value"
+            >any(report_lines.filtered(lambda x: x.position_sale_line))</attribute>
+    </xpath>
+
+    <xpath
+            expr="//table[@name='stock_move_line_table']/t[@t-set='has_line_position']"
+            position="attributes"
+        >
+      <attribute
+                name="t-value"
+            >any(report_lines.filtered(lambda x: x.position_sale_line))</attribute>
+    </xpath>
+
+  </template>
+
+  <template
+        id="report_delivery_document"
+        inherit_id="stock_picking_group_by_partner_by_carrier.report_delivery_document"
+    >
+
+    <!-- Add sale line position on remaining to deliver list -->
+    <xpath expr="//tr[@t-foreach='remainings']/td[1]/span[1]" position="before">
+      <span
+                t-if="remaining.get('sale_order_line')"
+                t-esc="remaining['sale_order_line'].position_formatted"
+            />
+    </xpath>
+
+  </template>
+
+</odoo>


### PR DESCRIPTION
Depends on 
- [x] https://github.com/OCA/sale-reporting/pull/114

The module `sale_order_line_position` is on `sale_reporting`.

First one `delivery_line_sale_line_position` adds the position
number on the delivery report.

And the second one `delivery_line_sale_line_position` is a glue
module with `stock_picking_group_by_partner_by_carrier` and
adds the position number on the remaining to deliver information.