### PR TITLE
[FIX] stock_picking_report_valued: access error

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -58,7 +58,11 @@ class StockMoveLine(models.Model):
         records...).
         """
         for line in self:
-            sale_line = line.sale_line
+            # In v12 the support for compute_sudo on non stored fields is
+            # limited (officially unsupported) so we have to mainaint some
+            # some sudo() calls. This is not necessary from v13
+            # https://github.com/odoo/odoo/blob/12.0/odoo/fields.py#L179
+            sale_line = line.sale_line.sudo()
             price_unit = (
                 sale_line.price_subtotal / sale_line.product_uom_qty
                 if sale_line.product_uom_qty else sale_line.price_reduce)

--- a/stock_picking_report_valued/models/stock_picking.py
+++ b/stock_picking_report_valued/models/stock_picking.py
@@ -43,7 +43,11 @@ class StockPicking(models.Model):
         for pick in self:
             round_curr = pick.sale_id.currency_id.round
             amount_tax = 0.0
-            for tax_id, tax_group in pick.get_taxes_values().items():
+            # In v12 the support for compute_sudo on non stored fields is
+            # limited (officially unsupported) so we have to mainaint some
+            # some sudo() calls. This is not necessary from v13
+            # https://github.com/odoo/odoo/blob/12.0/odoo/fields.py#L179
+            for tax_id, tax_group in pick.sudo().get_taxes_values().items():
                 amount_tax += round_curr(tax_group['amount'])
             amount_untaxed = sum(
                 l.sale_price_subtotal for l in pick.move_line_ids)


### PR DESCRIPTION
Steps to reproduce:

Try to print the delivery slip for a customer with valued report with a user with no sales permissions (or limited ones): Access Error

Looks like v12 ORM compute_sudo is limited for non stored fields (https://github.com/odoo/odoo/blob/12.0/odoo/fields.py#L179)

I tested the same issue in v13 and it works fine, so this patch would be only necessary up to this version.

cc @Tecnativa TT31027

please take a look @sergio-teruel @carlosdauden 