### PR TITLE
[13.0][FIX] s_p_group_by_partner_by_carrier: fix _get_sorted_moves by calling super()

### DIFF
--- a/stock_picking_group_by_partner_by_carrier_sale_line_position/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier_sale_line_position/models/stock_picking.py
@@ -8,8 +8,8 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     def _get_sorted_moves(self):
-        self.ensure_one()
-        return self.move_lines.sorted(
+        moves = super()._get_sorted_moves()
+        return moves.sorted(
             lambda m: m.sale_line_id.order_id.id * 1000 + m.sale_line_id.position
         )
 


### PR DESCRIPTION
Ref. 2967