### PR TITLE
[13.0][FIX] stock_account_quantity_history_location: location filter

### DIFF
--- a/stock_account_quantity_history_location/wizards/stock_quantity_history.py
+++ b/stock_account_quantity_history_location/wizards/stock_quantity_history.py
@@ -29,10 +29,23 @@ class StockQuantityHistory(models.TransientModel):
             )
             action["context"] = ctx
             if self.env.context.get("active_model") == "stock.valuation.layer":
+                operator = "child_of" if self.include_child_locations else "="
                 action["domain"] = expression.AND(
                     [
                         action["domain"],
-                        [("stock_move_id.location_dest_id", "=", self.location_id.id)],
+                        [
+                            "|",
+                            (
+                                "stock_move_id.location_dest_id",
+                                operator,
+                                self.location_id.id,
+                            ),
+                            (
+                                "stock_move_id.location_id",
+                                operator,
+                                self.location_id.id,
+                            ),
+                        ],
                     ]
                 )
         else:


### PR DESCRIPTION
When filtering svl by location we don't want to let outgoing svls out.
Normally, we want all the location's related movements to get the whole
picture.

I tried to also tried to use the `product.product._get_domain_locations()` method to get the child locations when those were active, but that aproach performs poorly. Probably we should hide that option in the wizard as it will be missleading.

cc @Tecnativa TT35218

What do you think @carlosdauden @victoralmau @pedrobaeza ?