### PR TITLE
[FIX] stock_picking_report_valued: avoid compute when no sale line

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -51,7 +51,7 @@ class StockMoveLine(models.Model):
         access to sales orders (stricter warehouse users, inter-company
         records...).
         """
-        for line in self:
+        for line in self.filtered("sale_line"):
             quantity = line._get_report_valued_quantity()
             valued_line = line.sale_line
             # If order line quantity don't match with move line quantity compute values


### PR DESCRIPTION
There could be some cases where the compute gets triggered but no sale
line is present. We should avoid them as we could get errors.

cc @Tecnativa TT37704

please check it @carlosdauden @sergio-teruel 