### PR TITLE
[15.0][FIX] stock_account_valuation_report: exclude JE that are not posted

### DIFF
--- a/stock_account_valuation_report/models/product_product.py
+++ b/stock_account_valuation_report/models/product_product.py
@@ -75,7 +75,9 @@ class ProductProduct(models.Model):
             sum(aml.balance), sum(quantity),
             array_agg(aml.id)
             FROM account_move_line AS aml
+            INNER JOIN account_move AS am ON am.id = aml.move_id
             WHERE aml.product_id IN %%s
+            AND am.state = 'posted'
             AND aml.company_id=%%s %s
             GROUP BY aml.product_id, aml.account_id"""
         params = (


### PR DESCRIPTION
Currenctly, draft and cancelled journal items make this report incorrect because the stock value is only counted when the journal entry is posted, indeed the stock_account module only posts inventory valuation JE when posting.

cc @ForgeFlow