### PR TITLE
[14.0][FIX] stock_account_quantity_history_location: remove domains

### DIFF
--- a/stock_account_quantity_history_location/__manifest__.py
+++ b/stock_account_quantity_history_location/__manifest__.py
@@ -10,7 +10,7 @@
         modules""",
     "version": "14.0.1.0.0",
     "license": "AGPL-3",
-    "author": "Eficent, Odoo Community Association (OCA)",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-reporting",
     "depends": ["stock_account", "stock_quantity_history_location"],
     "data": ["wizards/stock_quantity_history.xml"],

--- a/stock_account_quantity_history_location/readme/CONSTRIBUTORS.rst
+++ b/stock_account_quantity_history_location/readme/CONSTRIBUTORS.rst
@@ -1,4 +1,6 @@
-* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* `ForgeFlow <https://www.forgeflow.com>`_:
+
+  * Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
 
 * `Tecnativa <https://www.tecnativa.com>`_:
 

--- a/stock_account_quantity_history_location/wizards/stock_quantity_history.py
+++ b/stock_account_quantity_history_location/wizards/stock_quantity_history.py
@@ -1,11 +1,10 @@
-# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2019-22 ForgeFlow, S.L.
 # Copyright 2019 Aleph Objects, Inc.
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import ast
 
 from odoo import models
-from odoo.osv import expression
 
 
 class StockQuantityHistory(models.TransientModel):
@@ -28,22 +27,4 @@ class StockQuantityHistory(models.TransientModel):
                 self.location_id.complete_name,
             )
             action["context"] = ctx
-            if self.env.context.get("active_model") == "stock.valuation.layer":
-                action["domain"] = expression.AND(
-                    [
-                        action["domain"],
-                        [("stock_move_id.location_dest_id", "=", self.location_id.id)],
-                    ]
-                )
-        else:
-            # Show 0 quantities on Inventory Valuation to display Account Valuation
-            # anomalies, such as, non 0 stock_value on cost_method FIFO
-            if self.env.context.get("active_model") == "stock.valuation.layer":
-                action["domain"] = expression.AND(
-                    [action["domain"], [("quantity", "!=", 0)]]
-                )
-            else:
-                action["domain"] = expression.AND(
-                    [action["domain"], [("qty_available", "!=", 0)]]
-                )
         return action


### PR DESCRIPTION
Remove domains introduced in f4f1466973032a824a6951c1e1c8fe8999ab52cf
that make the valuation incorrect.

@victoralmau you introduce those changes. But we are having trouble due to those, as the inventory valuation shown is wrong, as a result of it. Layers with quantity 0 are normal (in case of landed costs, FIFO vacuum,..), and they shall be included in the report. They are included in the standard valuation report. Why should they be excluded here?