### PR TITLE
[13.0][FIX] stock_inventory_valuation_pivot: pivot on date wizard

### DIFF
--- a/stock_inventory_valuation_pivot/views/stock_account_views.xml
+++ b/stock_inventory_valuation_pivot/views/stock_account_views.xml
@@ -32,4 +32,10 @@
     >
         <field name="view_mode">tree,form,pivot</field>
     </record>
+    <record
+        id="stock_account.stock_valuation_layer_action"
+        model="ir.actions.act_window"
+    >
+        <field name="view_mode">tree,form,pivot</field>
+    </record>
 </odoo>


### PR DESCRIPTION
When we use the *Inventory at date* wizard, we were loosing the pivot view option.

cc @Tecnativa TT38649

please review @victoralmau @CarlosRoca13 