### PR TITLE
[14.0][FIX] stock_account_quantity_history_location: 2 fw-ports

### DIFF
--- a/stock_account_quantity_history_location/wizards/stock_quantity_history.py
+++ b/stock_account_quantity_history_location/wizards/stock_quantity_history.py
@@ -29,10 +29,23 @@ class StockQuantityHistory(models.TransientModel):
             )
             action["context"] = ctx
             if self.env.context.get("active_model") == "stock.valuation.layer":
+                operator = "child_of" if self.include_child_locations else "="
                 action["domain"] = expression.AND(
                     [
                         action["domain"],
-                        [("stock_move_id.location_dest_id", "=", self.location_id.id)],
+                        [
+                            "|",
+                            (
+                                "stock_move_id.location_dest_id",
+                                operator,
+                                self.location_id.id,
+                            ),
+                            (
+                                "stock_move_id.location_id",
+                                operator,
+                                self.location_id.id,
+                            ),
+                        ],
                     ]
                 )
         return action

--- a/stock_account_quantity_history_location/wizards/stock_quantity_history.py
+++ b/stock_account_quantity_history_location/wizards/stock_quantity_history.py
@@ -35,15 +35,4 @@ class StockQuantityHistory(models.TransientModel):
                         [("stock_move_id.location_dest_id", "=", self.location_id.id)],
                     ]
                 )
-        else:
-            # Show 0 quantities on Inventory Valuation to display Account Valuation
-            # anomalies, such as, non 0 stock_value on cost_method FIFO
-            if self.env.context.get("active_model") == "stock.valuation.layer":
-                action["domain"] = expression.AND(
-                    [action["domain"], [("quantity", "!=", 0)]]
-                )
-            else:
-                action["domain"] = expression.AND(
-                    [action["domain"], [("qty_available", "!=", 0)]]
-                )
         return action


### PR DESCRIPTION
- Remove domains introduced in https://github.com/OCA/stock-logistics-reporting/commit/f4f1466973032a824a6951c1e1c8fe8999ab52cf that make the valuation incorrect.
- When filtering svl by location we don't want to let outgoing svls out. Normally, we want all the location's related movements to get the whole picture.

FW-ports of #185 and #212

@Tecnativa