### PR TITLE
[14.0][FIX] stock_picking_report_valued: Calculate price unit correctly con…

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -21,7 +21,9 @@ class StockMoveLine(models.Model):
         related="sale_line.tax_id", readonly=True, string="Sale Tax"
     )
     sale_price_unit = fields.Float(
-        related="sale_line.price_unit", readonly=True, string="Sale price unit"
+        compute="_compute_sale_order_line_fields",
+        readonly=True,
+        string="Sale price unit",
     )
     sale_discount = fields.Float(
         related="sale_line.discount", readonly=True, string="Sale discount (%)"
@@ -54,6 +56,7 @@ class StockMoveLine(models.Model):
         for line in self:
             quantity = line._get_report_valued_quantity()
             valued_line = line.sale_line
+            sale_line_uom = valued_line.product_uom
             # If order line quantity don't match with move line quantity compute values
             if float_compare(
                 quantity,
@@ -68,6 +71,10 @@ class StockMoveLine(models.Model):
                 valued_line.product_uom_qty = quantity
                 # Force original price unit to avoid pricelist recomputed (not needed)
                 valued_line.price_unit = line.sale_line.price_unit
+            if sale_line_uom != line.product_uom_id:
+                valued_line.price_unit = sale_line_uom._compute_price(
+                    valued_line.price_unit, line.product_uom_id
+                )
             line.update(
                 {
                     "sale_tax_description": ", ".join(
@@ -76,5 +83,6 @@ class StockMoveLine(models.Model):
                     "sale_price_subtotal": valued_line.price_subtotal,
                     "sale_price_tax": valued_line.price_tax,
                     "sale_price_total": valued_line.price_total,
+                    "sale_price_unit": valued_line.price_unit,
                 }
             )


### PR DESCRIPTION
…sidering uom

Backport of #217 

We fixed the calculation error of price unit on the stock picking report valued.

Before: Directly got value of price unit without looking at the unit of measure on the sale order.

Now: It takes into account the conversion ratio between the unit of measure on the sale order and the unit of measure on the stock picking in order to get the real price unit.