### PR TITLE
[FIX] Always show qty_done on picking report:

### DIFF
--- a/stock_picking_report_valued/report/stock_picking_report_valued.xml
+++ b/stock_picking_report_valued/report/stock_picking_report_valued.xml
@@ -90,9 +90,7 @@
                         <span t-field="move_line.product_uom_qty" />
                         <span t-field="move_line.product_uom_id" /></td>
                 </t>
-                <t
-                    t-elif="move_line.picking_id.state == 'done' and move_line.product_uom_qty == 0"
-                >
+                <t t-elif="move_line.picking_id.state == 'done'">
                     <td class="text-right">
                         <span t-field="move_line.qty_done" />
                         <span t-field="move_line.product_uom_id" /></td>


### PR DESCRIPTION
- In standard report, Odoo always show qty_done