### PR TITLE
[14.0][FIX] stock_picking_report_valued: Remove WARNING log error.

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -24,6 +24,7 @@ class StockMoveLine(models.Model):
         compute="_compute_sale_order_line_fields",
         readonly=True,
         string="Sale price unit",
+        compute_sudo=True,
     )
     sale_discount = fields.Float(
         related="sale_line.discount", readonly=True, string="Sale discount (%)"


### PR DESCRIPTION
Remove WARNING log error.

`WARNING odoo.modules.registry: stock.move.line: inconsistent 'compute_sudo' for computed fields: sale_price_unit, sale_tax_description, sale_price_subtotal, sale_price_tax, sale_price_total`

Please @pedrobaeza can you review it?

@Tecnativa 