### PR TITLE
[15.0][FIX] stock_picking_report_valued: Fix on valued report

### DIFF
--- a/stock_picking_report_valued/report/stock_picking_report_valued.xml
+++ b/stock_picking_report_valued/report/stock_picking_report_valued.xml
@@ -104,7 +104,7 @@
                         <span t-field="move_line.qty_done" />
                         <span t-field="move_line.product_uom_id" /></td>
                 </t>
-            <t t-if="o.valued and o.sale_id and o.move_line_ids">
+            <t t-if="o.valued and o.sale_id and o.move_line_ids and is_outgoing">
                 <td class="text-right"><span t-field="move_line.sale_price_unit" /></td>
                 <td class="text-right" groups="product.group_discount_per_so_line">
                     <span t-field="move_line.sale_discount" />


### PR DESCRIPTION
Slight change is made in picking report so that unneccesary valued are not rendered when printing a picking which is not type outgoing.

This PR also fixes a traceback on non-outgoing pickings when lines are not related to a sale line. 

@bi-landoo @pedrobaeza @carlosdauden