### PR TITLE
[15.0][FIX] stock_picking_report_product_sticker: Show stickers in different positions

### DIFF
--- a/stock_picking_report_product_sticker/__manifest__.py
+++ b/stock_picking_report_product_sticker/__manifest__.py
@@ -18,6 +18,6 @@
         "report/report_deliveryslip.xml",
         "data/menus.xml",
     ],
-    "maintainer": ["Shide"],
+    "maintainers": ["Shide"],
     "installable": True,
 }

--- a/stock_picking_report_product_sticker/i18n/es.po
+++ b/stock_picking_report_product_sticker/i18n/es.po
@@ -7,58 +7,60 @@ msgstr ""
 "Project-Id-Version: Odoo Server 15.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-31 10:48+0000\n"
-"PO-Revision-Date: 2023-03-31 10:48+0000\n"
+"PO-Revision-Date: 2023-03-31 12:50+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.1.1\n"
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.model.fields.selection,name:stock_picking_report_product_sticker.selection__stock_picking__show_product_stickers__bottom_left
 #: model:ir.model.fields.selection,name:stock_picking_report_product_sticker.selection__stock_picking_type__show_product_stickers__bottom_left
 msgid "Bottom (left)"
-msgstr ""
+msgstr "Abajo (izquierda)"
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.model,name:stock_picking_report_product_sticker.model_stock_picking_type
 msgid "Picking Type"
-msgstr ""
+msgstr "Tipo de albarán"
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.model.fields,help:stock_picking_report_product_sticker.field_stock_picking_type__show_product_stickers
 msgid "Position of the stickers inside the report."
-msgstr ""
+msgstr "Posición de las pegatinas de producto dentro del informe."
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.ui.menu,name:stock_picking_report_product_sticker.menu_stock_picking_report_product_sticker
 msgid "Product Stickers"
-msgstr ""
+msgstr "Pegatinas de producto"
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.model.fields,field_description:stock_picking_report_product_sticker.field_stock_picking__show_product_stickers
 #: model:ir.model.fields,field_description:stock_picking_report_product_sticker.field_stock_picking_type__show_product_stickers
 msgid "Show Product Stickers"
-msgstr ""
+msgstr "Mostrar pegatinas de productos"
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.model.fields,help:stock_picking_report_product_sticker.field_stock_picking__show_product_stickers
 msgid "Show Product Stickers on pickings of this type."
-msgstr ""
+msgstr "Mostrar Pegatinas de productos en los albaranes de este tipo."
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.model.fields,field_description:stock_picking_report_product_sticker.field_stock_picking__sticker_ids
 msgid "Stickers"
-msgstr ""
+msgstr "Pegatinas"
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.model.fields.selection,name:stock_picking_report_product_sticker.selection__stock_picking__show_product_stickers__top_right
 #: model:ir.model.fields.selection,name:stock_picking_report_product_sticker.selection__stock_picking_type__show_product_stickers__top_right
 msgid "Top (right)"
-msgstr ""
+msgstr "Arriba (derecha)"
 
 #. module: stock_picking_report_product_sticker
 #: model:ir.model,name:stock_picking_report_product_sticker.model_stock_picking
 msgid "Transfer"
-msgstr ""
+msgstr "Albarán"

--- a/stock_picking_report_product_sticker/models/stock_picking.py
+++ b/stock_picking_report_product_sticker/models/stock_picking.py
@@ -3,15 +3,18 @@
 
 from odoo import api, fields, models
 
+from .stock_picking_type import REPORT_STICKER_POSITIONS
+
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    show_product_stickers = fields.Boolean(
-        help="Show Product Stickers on pickings of this type.",
+    show_product_stickers = fields.Selection(
+        selection=REPORT_STICKER_POSITIONS,
         compute="_compute_show_product_stickers",
         store=True,
         readonly=False,
+        help="Show Product Stickers on pickings of this type.",
     )
     sticker_ids = fields.Many2many(
         comodel_name="product.sticker",
@@ -20,7 +23,7 @@ class StockPicking(models.Model):
         store=False,
     )
 
-    @api.depends("picking_type_id.show_product_stickers")
+    @api.depends("picking_type_id")
     def _compute_show_product_stickers(self):
         for picking in self:
             picking.show_product_stickers = (

--- a/stock_picking_report_product_sticker/models/stock_picking_type.py
+++ b/stock_picking_report_product_sticker/models/stock_picking_type.py
@@ -3,10 +3,16 @@
 
 from odoo import fields, models
 
+REPORT_STICKER_POSITIONS = [
+    ("top_right", "Top (right)"),
+    ("bottom_left", "Bottom (left)"),
+]
+
 
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
-    show_product_stickers = fields.Boolean(
-        help="Show Product Stickers on Pickings of this type.",
+    show_product_stickers = fields.Selection(
+        selection=REPORT_STICKER_POSITIONS,
+        help="Display Product Stickers on chosen position inside the report.",
     )

--- a/stock_picking_report_product_sticker/readme/USAGE.rst
+++ b/stock_picking_report_product_sticker/readme/USAGE.rst
@@ -1,6 +1,6 @@
 To use this module, you need to:
 
 #. You must go to the Picking Type that you want to show the Product Stickers
-   and activate the option to *Show Stickers on Pickings of this type*.
-#. You can also enable or disable showing Stickers on each Picking by hand if you wish.
+   and choose the desired position of the stickers on the field *Show Product Stickers*.
+#. You can also change the position or disable it on each Picking by hand if you wish.
    Regardless if your Picking Type has Show Stickers enabled or not.

--- a/stock_picking_report_product_sticker/report/report_deliveryslip.xml
+++ b/stock_picking_report_product_sticker/report/report_deliveryslip.xml
@@ -8,9 +8,21 @@
     >
         <xpath expr="//div[hasclass('page')]" position="inside">
             <div
-                t-if="o.show_product_stickers"
-                name="delivery_sticker_section"
+                t-if="o.show_product_stickers == 'bottom_left'"
+                name="delivery_sticker_section_bottom"
                 class="mt-5"
+            >
+                <t
+                    t-call="stock_picking_report_product_sticker.stock_report_delivery_stickers"
+                />
+            </div>
+        </xpath>
+        <xpath expr="//div[hasclass('page')]/h2" position="before">
+            <div
+                t-if="o.show_product_stickers == 'top_right'"
+                name="delivery_sticker_section_top"
+                class="col-12 mt-1 mb-1"
+                style="text-align:end;"
             >
                 <t
                     t-call="stock_picking_report_product_sticker.stock_report_delivery_stickers"
@@ -21,16 +33,16 @@
 
     <template id="stock_report_delivery_stickers">
         <t t-foreach="o.sticker_ids" t-as="sticker">
-            <div class="col-2 d-inline-block text-center align-top p-0 mt-3 mr-1">
+            <div class="col-1 d-inline-block text-center align-top p-0 mt-3 mr-1">
                 <img
-                    t-att-src="image_data_uri(sticker.image_128)"
+                    t-att-src="image_data_uri(sticker.image_64)"
                     t-att-alt="sticker.name"
                     class="m-auto d-block"
                 />
                 <span
                     t-if="sticker.show_sticker_note and sticker.note"
                     t-esc="sticker.note"
-                    class="text-muted"
+                    class="text-muted small"
                     style="white-space: pre;"
                 />
             </div>

--- a/stock_picking_report_product_sticker/tests/common.py
+++ b/stock_picking_report_product_sticker/tests/common.py
@@ -5,6 +5,8 @@ from odoo.tests import tagged
 
 from odoo.addons.product_sticker.tests.common import ProductStickerCommon
 
+from ..models.stock_picking_type import REPORT_STICKER_POSITIONS
+
 
 @tagged("post_install", "-at_install")
 class ProductStickerStockCommon(ProductStickerCommon):
@@ -12,7 +14,7 @@ class ProductStickerStockCommon(ProductStickerCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.picking_type_out = cls.env.ref("stock.picking_type_out")
-        cls.picking_type_out.show_product_stickers = True
+        cls.picking_type_out.show_product_stickers = REPORT_STICKER_POSITIONS[0][0]
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
 

--- a/stock_picking_report_product_sticker/tests/test_stock_picking.py
+++ b/stock_picking_report_product_sticker/tests/test_stock_picking.py
@@ -11,8 +11,10 @@ class TestStickersOnPickings(ProductStickerStockCommon):
         picking = self._create_picking(
             self.picking_type_out, [target_product, target_product]
         )
-        self.assertTrue(
-            picking.show_product_stickers, "Picking type should show stickers"
+        self.assertEqual(
+            picking.show_product_stickers,
+            self.picking_type_out.show_product_stickers,
+            "Picking type should show stickers",
         )
         self.assertEqual(
             picking.sticker_ids,

--- a/stock_picking_report_product_sticker/views/stock_picking_type_views.xml
+++ b/stock_picking_report_product_sticker/views/stock_picking_type_views.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='show_operations']" position="after">
-                <field name="show_product_stickers" widget="boolean_toggle" />
+                <field name="show_product_stickers" />
             </xpath>
         </field>
     </record>

--- a/stock_picking_report_product_sticker/views/stock_picking_views.xml
+++ b/stock_picking_report_product_sticker/views/stock_picking_views.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='other_infos']" position="inside">
-                <field name="show_product_stickers" widget="boolean_toggle" />
+                <field name="show_product_stickers" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Show stickers in different positions and reduce the image size on the report.

Top position:
![top](https://user-images.githubusercontent.com/1162050/229101963-724f032d-140f-4dc7-970c-391524fb2932.png)

Bottom position:
![bottom](https://user-images.githubusercontent.com/1162050/229101969-c8ea371f-46c7-4159-a596-74d1fdc5052e.png)


MT-2153 @moduon @rafaelbn @yajo please review