### PR TITLE
[15.0][FIX] stock_card_report: display the correct product name

### DIFF
--- a/stock_card_report/reports/stock_card_report.xml
+++ b/stock_card_report/reports/stock_card_report.xml
@@ -54,7 +54,7 @@
         <t t-foreach="o.product_ids" t-as="product">
             <div class="page">
                 <div class="row">
-                    <t t-set="title">Stock Card - <t t-out="product.name" /></t>
+                    <t t-set="title">Stock Card - <t t-out="product.display_name" /></t>
                     <h4 class="mt0" t-out="title" style="text-align: center;" />
                 </div>
                 <!-- Display filters -->

--- a/stock_card_report/reports/stock_card_report_xlsx.py
+++ b/stock_card_report/reports/stock_card_report_xlsx.py
@@ -99,9 +99,9 @@ class ReportStockCardReportXlsx(models.AbstractModel):
         }
 
         ws_params = {
-            "ws_name": product.name,
+            "ws_name": product.display_name,
             "generate_ws_method": "_stock_card_report",
-            "title": "Stock Card - {}".format(product.name),
+            "title": "Stock Card - {}".format(product.display_name),
             "wanted_list_filter": [k for k in sorted(filter_template.keys())],
             "col_specs_filter": filter_template,
             "wanted_list_initial": [k for k in sorted(initial_template.keys())],


### PR DESCRIPTION
Show the product name with an attribute instead of the product name.