### PR TITLE
[16.0][FIX] stock_picking_report_valued: First description taxes

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -87,7 +87,7 @@ class StockMoveLine(models.Model):
             line.update(
                 {
                     "sale_tax_description": ", ".join(
-                        t.name or t.description for t in line.sale_tax_id
+                        t.description or t.name for t in line.sale_tax_id
                     ),
                     "sale_price_subtotal": valued_line.price_subtotal,
                     "sale_price_tax": valued_line.price_tax,


### PR DESCRIPTION
In invoices and sales, first use description tax and after name tax to show taxes. This report shoul be the same.
https://github.com/odoo/odoo/blob/16.0/addons/account/views/report_invoice.xml#L128
https://github.com/odoo/odoo/blob/16.0/addons/sale/report/ir_actions_report_templates.xml#L108

@yajo @rafaelbn @Shide please review.

MT-5850 @moduon