### PR TITLE
[FIX] stock_picking_report_valued: Dicount computed zero in new line

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -77,6 +77,9 @@ class StockMoveLine(models.Model):
                 sol_vals = line.sale_line._convert_to_write(line.sale_line._cache)
                 valued_line = line.sale_line.new(sol_vals)
                 valued_line.product_uom_qty = quantity
+                # When a new line is created, sometimes the discount is computed to zero
+                # even if the field is originally non-zero.
+                valued_line.discount = line.sale_line.discount
             if different_qty:
                 # Force original price unit to avoid pricelist recomputed (not needed)
                 valued_line.price_unit = line.sale_line.price_unit


### PR DESCRIPTION
Even sale line have set discount, when new line is created, compute method to discount field can calculate zero.

@yajo @Shide @Gelojr @fcvalgar @rafaelbn please review.

MT-5982 @moduon