### PR TITLE
[16.0][FIX] stock_picking_report_salesperson: add the same class style as in the base report

### DIFF
--- a/stock_picking_report_salesperson/report/report_deliveryslip.xml
+++ b/stock_picking_report_salesperson/report/report_deliveryslip.xml
@@ -4,11 +4,11 @@
         <xpath expr="//div[@name='div_origin']/.." position="inside">
             <div
                 t-if="o.picking_type_id.code == 'outgoing' and o.sale_id.user_id"
-                class="col-auto"
+                class="col-auto col-3 mw-100 mb-2"
                 name="div_salesperson"
             >
                 <strong>Salesperson:</strong>
-                <p t-field="o.sale_id.user_id.name" />
+                <p t-field="o.sale_id.user_id.name" class="m-0" />
             </div>
         </xpath>
     </template>


### PR DESCRIPTION
This [PR](https://github.com/odoo/odoo/pull/172366) accepts a change that fixes how the information section looks like.

It is necessary to change the views that add changes in this section.

Without the change:

![Selección_1017](https://github.com/OCA/stock-logistics-reporting/assets/6359121/20f4cf7b-db18-406c-b8cb-4516e3929cec)

With the change:

![Selección_1018](https://github.com/OCA/stock-logistics-reporting/assets/6359121/95545a68-ec6d-4be7-be42-7e77e6f3869f)
