### PR TITLE
[15.0][FIX] stock_picking_report_valued_sale_mrp: non existing backorder_id in stock.move

### DIFF
--- a/stock_picking_report_valued_sale_mrp/models/stock_move.py
+++ b/stock_picking_report_valued_sale_mrp/models/stock_move.py
@@ -22,7 +22,10 @@ class StockMove(models.Model):
             sale_line.move_ids.filtered(
                 lambda x: x.product_id == self.product_id
                 and not x.origin_returned_move_id
-                and (x.state != "cancel" or (x.state == "cancel" and x.backorder_id))
+                and (
+                    x.state != "cancel"
+                    or (x.state == "cancel" and x.picking_id.backorder_id)
+                )
             ).mapped("product_uom_qty")
         )
         return component_demand / sale_line.product_uom_qty


### PR DESCRIPTION
It was a related field in v13, but now it's only on the picking, so let's access to it in the code.

@Tecnativa TT50285