### PR TITLE
[16.0][IMP] stock_account_valuation_report: filters added are more useful displayed with AND conditions

### DIFF
--- a/stock_account_valuation_report/views/product_product_views.xml
+++ b/stock_account_valuation_report/views/product_product_views.xml
@@ -79,16 +79,19 @@
                     name="real_valuation"
                     domain="[('valuation', '=', 'real_time')]"
                 />
+                <separator />
                 <filter
                     string="Manual"
                     name="manual_valuation"
                     domain="[('valuation', '=', 'manual_periodic')]"
                 />
+                <separator />
                 <filter
                     string="Qty Discrepancy"
                     name="qty_discrepancy_not_null"
                     domain="[('qty_discrepancy', '!=', 0.0), ('valuation', '=', 'real_time')]"
                 />
+                <separator />
                 <filter
                     string="Valuation Discrepancy"
                     name="valuation_discrepancy_not_null"


### PR DESCRIPTION
Displaying those as OR conditions is not much useful

- Real Time OR Valuation Discrepancy: Not useful filter


Typically filters are:
- Real Time AND Valuation Discrepancy
- Real Time AND Quantity Discrepancy

![image](https://github.com/user-attachments/assets/e3af38a0-9568-4b13-af55-cefc3d997ce6)

cc @ForgeFlow