### PR TITLE
[16.0][IMP] stock_quantity_history_location: add usage view

### DIFF
--- a/stock_quantity_history_location/wizards/stock_quantity_history.py
+++ b/stock_quantity_history_location/wizards/stock_quantity_history.py
@@ -11,7 +11,7 @@ class StockQuantityHistory(models.TransientModel):
     _inherit = "stock.quantity.history"
 
     location_id = fields.Many2one(
-        "stock.location", domain=[("usage", "in", ["internal", "transit"])]
+        "stock.location", domain=[("usage", "in", ["view", "internal", "transit"])]
     )
     include_child_locations = fields.Boolean(default=True)
 


### PR DESCRIPTION
Let the user select usage (location type) 'view' to select all child location. 
This is useful if you have a location that has a direct parent to the usage (location type) 'view'.

  
