### PR TITLE
[16.0][FIX] stock_picking_report_custom_description: avoid dupe product name

### DIFF
--- a/stock_picking_report_custom_description/models/stock_rule.py
+++ b/stock_picking_report_custom_description/models/stock_rule.py
@@ -31,6 +31,15 @@ class StockRule(models.Model):
         )
         if values.get("sale_line_id"):
             line = self.env["sale.order.line"].browse(values["sale_line_id"])
-            res["description_picking"] = line.name
+            # Avoid double printing the name in the picking
+            pattern = f"{line.product_id.display_name}\n"
+            description_picking = line.name
+            if description_picking.startswith(pattern):
+                description_picking = description_picking.replace(pattern, "")
+            if (
+                description_picking
+                and description_picking != line.product_id.display_name
+            ):
+                res["description_picking"] = description_picking
             res["name"] = line.name
         return res

--- a/stock_picking_report_custom_description/tests/test_stock_picking_report_custom_description.py
+++ b/stock_picking_report_custom_description/tests/test_stock_picking_report_custom_description.py
@@ -11,13 +11,16 @@ class TestStockPickingReportCustomDescription(common.TransactionCase):
         super().setUpClass()
         cls.customer = cls.env["res.partner"].create({"name": "Test customer"})
         cls.product = cls.env["product.product"].create(
-            {"name": "Test product", "type": "product"}
+            {
+                "name": "Test product",
+                "type": "product",
+                "description_sale": "Custom description",
+            }
         )
         order_form = common.Form(cls.env["sale.order"])
         order_form.partner_id = cls.customer
         with order_form.order_line.new() as line_form:
             line_form.product_id = cls.product
-            line_form.name = "Custom description"
         cls.order = order_form.save()
 
     def test_so_custom_description_transfer_to_picking(self):


### PR DESCRIPTION
By default the sale description is set as
f"{product_name}\n{description". If we pass that string as the description_picking, when we print the report, the name will be duplicated. To avoid that effect, we want to trim the product name from the description passed to the picking by default.

cc @Tecnativa TT52044

please review @pedrobaeza @pilarvargas-tecnativa 