### PR TITLE
[FIX] stock_average_daily_sale: include weekends in demo data

### DIFF
--- a/stock_average_daily_sale/demo/stock_average_daily_sale_config.xml
+++ b/stock_average_daily_sale/demo/stock_average_daily_sale_config.xml
@@ -12,7 +12,7 @@
         <field name="standard_deviation_exclude_factor">3</field>
         <field name="safety_factor">0.3</field>
         <field name="number_days_qty_in_stock">2</field>
-        <field name="exclude_weekends">1</field>
+        <field name="exclude_weekends">0</field>
         <field name="warehouse_id" ref="stock.warehouse0" />
         <field name="company_id" ref="base.main_company" />
     </record>
@@ -26,7 +26,7 @@
         <field name="standard_deviation_exclude_factor">3</field>
         <field name="safety_factor">0.3</field>
         <field name="number_days_qty_in_stock">2</field>
-        <field name="exclude_weekends">1</field>
+        <field name="exclude_weekends">0</field>
         <field name="warehouse_id" ref="stock.warehouse0" />
         <field name="company_id" ref="base.main_company" />
     </record>
@@ -40,7 +40,7 @@
         <field name="standard_deviation_exclude_factor">3</field>
         <field name="safety_factor">0.3</field>
         <field name="number_days_qty_in_stock">2</field>
-        <field name="exclude_weekends">1</field>
+        <field name="exclude_weekends">0</field>
         <field name="warehouse_id" ref="stock.warehouse0" />
         <field name="company_id" ref="base.main_company" />
     </record>


### PR DESCRIPTION
In the test modified by the commit [fc5e8bcdfaf08c06b7f10e6ab7464e330ec86162](https://github.com/OCA/stock-logistics-reporting/commit/fc5e8bcdfaf08c06b7f10e6ab7464e330ec86162), the stock.move is created with yesterday's date. In the demo data, weekends were excluded from the calculation, which resulted in the test failing sometimes (on Sundays and Mondays). Including weekends in the demo config solves this issue.