### PR TITLE
[14.0][FIX] stock_average_daily_sale: make sure joining on unique ids

### DIFF
--- a/stock_average_daily_sale/models/stock_average_daily_sale.py
+++ b/stock_average_daily_sale/models/stock_average_daily_sale.py
@@ -232,7 +232,7 @@ class StockAverageDailySale(models.Model):
                 averages AS(
                     SELECT
                         row_number() over (order by product_id) as id,
-                        concat(warehouse_id, product_id)::integer as window_id,
+                        concat(warehouse_id, '-', product_id) as window_id,
                         product_id,
                         warehouse_id,
                         (avg(product_uom_qty) FILTER
@@ -272,7 +272,7 @@ class StockAverageDailySale(models.Model):
                         from (
                             SELECT
                                 to_char(date_trunc('day', date), 'YYYY-MM-DD'),
-                                concat(warehouse_id, product_id)::integer as id,
+                                concat(warehouse_id, '-', product_id) as id,
                                 product_id,
                                 warehouse_id,
                                 (count(product_uom_qty) FILTER


### PR DESCRIPTION
Concatenation of `warehouse_id` and `product_id` may have resulted in duplicated values in case of having more than 10 warehouses (`select concat(11, 2)::integer = concat(1, 12)::integer` -> true) impacting the `join` in materialized view query (`JOIN daily_standard_deviation ds on ds.id= t.window_id`). With this PR we make sure to have a unique value after concatenation.