### PR TITLE
[15.0][IMP] stock_picking_report_custom_description: update description

### DIFF
--- a/stock_picking_report_custom_description/README.rst
+++ b/stock_picking_report_custom_description/README.rst
@@ -30,6 +30,7 @@ Stock Picking Report Custom Description
 
 This module transfers the sales order line description to the picking, and
 allows to print such text on the picking reports.
+When the sales order line description is changed, picking description is updated.
 
 **Table of contents**
 

--- a/stock_picking_report_custom_description/models/__init__.py
+++ b/stock_picking_report_custom_description/models/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import stock_rule
+from . import sale_order_line

--- a/stock_picking_report_custom_description/models/sale_order_line.py
+++ b/stock_picking_report_custom_description/models/sale_order_line.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Tecnativa - Carolina Fernandez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get("name"):
+            self.env["stock.move"].search(
+                [("sale_line_id", "in", self.ids)]
+            ).name = vals["name"]
+        return res

--- a/stock_picking_report_custom_description/readme/DESCRIPTION.rst
+++ b/stock_picking_report_custom_description/readme/DESCRIPTION.rst
@@ -1,2 +1,3 @@
 This module transfers the sales order line description to the picking, and
 allows to print such text on the picking reports.
+When the sales order line description is changed, picking description is updated.

--- a/stock_picking_report_custom_description/static/description/index.html
+++ b/stock_picking_report_custom_description/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -371,7 +371,8 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/stock-logistics-reporting/tree/15.0/stock_picking_report_custom_description"><img alt="OCA/stock-logistics-reporting" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--reporting-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/stock-logistics-reporting-15-0/stock-logistics-reporting-15-0-stock_picking_report_custom_description"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/stock-logistics-reporting&amp;target_branch=15.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module transfers the sales order line description to the picking, and
-allows to print such text on the picking reports.</p>
+allows to print such text on the picking reports.
+When the sales order line description is changed, picking description is updated.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -431,7 +432,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/stock_picking_report_custom_description/tests/test_stock_picking_report_custom_description.py
+++ b/stock_picking_report_custom_description/tests/test_stock_picking_report_custom_description.py
@@ -22,3 +22,8 @@ class TestStockPickingReportCustomDescription(common.TransactionCase):
     def test_so_custom_description_transfer_to_picking(self):
         self.order.action_confirm()
         self.assertEqual(self.order.order_line.move_ids.name, "Custom description")
+        self.order.order_line.name = "Custom description 2"
+        self.assertEqual(
+            self.order.order_line.move_ids.name,
+            "Custom description 2",
+        )


### PR DESCRIPTION
Partially backported from the v16 feature

Before this change only when the procurements where updated the sale line description would be propagated so if a user updated that description after the sale was confirmed it wouldn't be written to the picking move.

Now every time the user changes the line it will be synced to the related moves.

cc @Tecnativa TT52171


please review @pilarvargas-tecnativa @carlos-lopez-tecnativa 