### PR TITLE
[16.0][FIX] stock_account_valuation_discrepancy_adjust: Let the user change the date of the adjustment

### DIFF
--- a/stock_account_valuation_discrepancy_adjust/tests/test_stock_account_valuation_discrepancy_adjust.py
+++ b/stock_account_valuation_discrepancy_adjust/tests/test_stock_account_valuation_discrepancy_adjust.py
@@ -3,6 +3,8 @@
 
 import time
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import fields
 from odoo.tests.common import TransactionCase
 
@@ -188,9 +190,39 @@ class TestStockAccountValuationDiscrepancy(TransactionCase):
                     "increase_account_id": self.account_cogs.id,
                     "decrease_account_id": self.account_cogs.id,
                     "journal_id": self.journal.id,
+                    "to_date": fields.Date.today(),
                 }
             )
         )
         wiz.with_context(no_delay=True).action_create_adjustment()
         self.product_fifo_1._compute_inventory_value()
         self.assertEqual(self.product_fifo_1.valuation_discrepancy, 0.0)
+
+    def test_02_manual_adjustment_past_date(self):
+        """Test the journal entry creation on a past date"""
+        past_date = fields.Date.to_string(
+            fields.Date.from_string(fields.Date.today()) - relativedelta(days=30)
+        )
+        self.product_fifo_1._compute_inventory_value()
+        wiz = (
+            self.env["wizard.stock.discrepancy.adjustment"]
+            .with_context(
+                active_model="product.product",
+                active_ids=[self.product_fifo_1.id],
+                active_id=self.product_fifo_1.id,
+            )
+            .create(
+                {
+                    "increase_account_id": self.account_cogs.id,
+                    "decrease_account_id": self.account_cogs.id,
+                    "journal_id": self.journal.id,
+                    "to_date": past_date,
+                }
+            )
+        )
+        action = wiz.with_context(no_delay=True).action_create_adjustment()
+        # Check that the journal entries were created with the correct past date
+        moves = self.account_move_model.search(action["domain"])
+        self.assertTrue(moves)
+        for move in moves:
+            self.assertEqual(move.date, fields.Date.from_string(past_date))

--- a/stock_account_valuation_discrepancy_adjust/wizards/wizard_stock_discrepancy_adjustment.py
+++ b/stock_account_valuation_discrepancy_adjust/wizards/wizard_stock_discrepancy_adjustment.py
@@ -65,11 +65,6 @@ class WizardStockDiscrepancyAdjustment(models.TransientModel):
         values["product_selection_ids"] = [
             (0, 0, {"product_id": product.id}) for product in products
         ]
-        to_date = self.env.context.get("at_date", False)
-        if to_date:
-            values["to_date"] = to_date
-        else:
-            values["to_date"] = fields.Datetime.now()
         return values
 
     def action_create_adjustment(self):

--- a/stock_account_valuation_discrepancy_adjust/wizards/wizard_stock_discrepancy_adjustment_view.xml
+++ b/stock_account_valuation_discrepancy_adjust/wizards/wizard_stock_discrepancy_adjustment_view.xml
@@ -7,7 +7,7 @@
             <form string="wizard_stock_discrepancy_adjustment_form">
                 <sheet>
                     <group>
-                    <field name="to_date" readonly="1" />
+                        <field name="to_date" />
                         <field name="journal_id" />
                         <field name="increase_account_id" />
                         <field name="decrease_account_id" />


### PR DESCRIPTION
Adjustment on past custom date should be possible:

![image](https://github.com/user-attachments/assets/fce1ecc5-24e5-4512-97aa-d873b34397b2)

Currently all adjustments are created only on today's date.

cc @ForgeFlow