### PR TITLE
[FIX] [16.0] stock_picking_report_product_sticker: Select which model are being requesting stickers

### DIFF
--- a/stock_picking_report_product_sticker/models/stock_picking.py
+++ b/stock_picking_report_product_sticker/models/stock_picking.py
@@ -36,7 +36,10 @@ class StockPicking(models.Model):
         for picking in self:
             if not picking.show_product_stickers:
                 continue
-            products = picking.move_line_ids.product_id
-            stickers = products.get_product_stickers()
-            if stickers:
-                picking.sticker_ids = stickers
+            picking.sticker_ids = picking.move_line_ids.product_id.get_product_stickers(
+                extra_domain=[
+                    "|",
+                    ("available_model_ids.model", "in", [self._name]),
+                    ("available_model_ids", "=", False),
+                ]
+            )


### PR DESCRIPTION
Update how it works to match the new arguments.

This PR needs to be merged first in order to work: https://github.com/OCA/product-attribute/pull/1893

MT-9075 @moduon @rafaelbn @yajo @fcvalgar @EmilioPascual please review if you want 😄 