### PR TITLE
[FIX] [16.0] stock_picking_report_product_sticker: allow stock users to print stickers

### DIFF
--- a/stock_picking_report_product_sticker/models/stock_picking.py
+++ b/stock_picking_report_product_sticker/models/stock_picking.py
@@ -21,6 +21,7 @@ class StockPicking(models.Model):
         string="Stickers",
         compute="_compute_sticker_ids",
         store=False,
+        compute_sudo=True,
     )
 
     @api.depends("picking_type_id")

--- a/stock_picking_report_product_sticker/tests/common.py
+++ b/stock_picking_report_product_sticker/tests/common.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Moduon Team S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
 
-from odoo.tests import tagged
+from odoo.tests import new_test_user, tagged
 
 from odoo.addons.product_sticker.tests.common import ProductStickerCommon
 
@@ -17,6 +17,11 @@ class ProductStickerStockCommon(ProductStickerCommon):
         cls.picking_type_out.show_product_stickers = REPORT_STICKER_POSITIONS[0][0]
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+        cls.env = cls.env(
+            user=new_test_user(
+                cls.env, "test_stock_user", groups="stock.group_stock_user"
+            )
+        )
 
     def _create_picking(self, picking_type, products):
         return self.env["stock.picking"].create(


### PR DESCRIPTION
Since the domain inside `_compute_sticker_ids` requires access to the `ir.model` model, only admins could print stickers. Other users were getting an `AccessError`.
Now tests are executed with an stock user. Running them like this without the fix triggers the error.

Related PR: https://github.com/OCA/account-invoice-reporting/pull/360

MT-9304 @moduon @yajo @rafaelbn @fcvalgar please review if you want 😄 