### PR TITLE
[IMP][17.0] stock_picking_report_valued: Configuration for printing picking valued on the same picking

### DIFF
--- a/stock_picking_report_valued/README.rst
+++ b/stock_picking_report_valued/README.rst
@@ -33,6 +33,11 @@ partner level if picking list report must be valued or not. If the
 picking is done it's valued with quantity done, otherwise the picking is
 valued with reserved quantity.
 
+Additionally, you can configure each individual picking to be valued or
+not, regardless of the partner's configuration. This allows for more
+flexibility when generating delivery slips for different purposes or
+recipients.
+
 **Table of contents**
 
 .. contents::
@@ -41,9 +46,17 @@ valued with reserved quantity.
 Configuration
 =============
 
+To configure valued pickings at partner level:
+
 1. Go to *Sales > Orders > Customers > (select one of your choice) >
    Sales & Purchases*.
 2. Set *Valued picking* field on.
+
+To enable the valued picking option directly on picking forms:
+
+1. Go to *Inventory > Configuration > Settings*.
+2. Check the option *Display Valued Picking* in the Delivery section.
+3. Click on *Save*.
 
 Usage
 =====
@@ -55,6 +68,15 @@ To get the stock picking valued report:
 2. Confirm the Sale Order.
 3. Click on *Delivery* stat button.
 4. Go to *Print > Delivery Slip*.
+
+Alternatively, you can configure the valued report option directly on
+the picking:
+
+1. Open a stock picking.
+2. Check or uncheck the *Valued* checkbox (only visible if the company
+   setting is enabled).
+3. Go to *Print > Delivery Slip* to get the report with or without
+   values accordingly.
 
 Known issues / Roadmap
 ======================
@@ -118,6 +140,10 @@ Contributors
 - `Trobz <https://trobz.com>`__:
 
   - Nguyen Minh Chien <chien@trobz.com>
+
+- `Binhex <https://binhex.cloud>`__
+
+  - Antonio Ruban <antoniodavid8@gmail.com>
 
 Maintainers
 -----------

--- a/stock_picking_report_valued/__manifest__.py
+++ b/stock_picking_report_valued/__manifest__.py
@@ -14,6 +14,11 @@
     "category": "Warehouse Management",
     "license": "AGPL-3",
     "depends": ["sale_stock"],
-    "data": ["views/res_partner_view.xml", "report/stock_picking_report_valued.xml"],
+    "data": [
+        "views/res_config_settings_views.xml",
+        "views/res_partner_view.xml",
+        "views/stock_picking_views.xml",
+        "report/stock_picking_report_valued.xml",
+    ],
     "installable": True,
 }

--- a/stock_picking_report_valued/i18n/es.po
+++ b/stock_picking_report_valued/i18n/es.po
@@ -4,18 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0c\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-21 08:13+0000\n"
-"PO-Revision-Date: 2023-11-20 10:35+0000\n"
-"Last-Translator: Gelojr <gelo@moduon.team>\n"
+"POT-Creation-Date: 2025-04-09 14:34+0000\n"
+"PO-Revision-Date: 2025-04-09 14:34+0000\n"
+"Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: stock_picking_report_valued
 #: model_terms:ir.ui.view,arch_db:stock_picking_report_valued.valued_report_picking
@@ -25,7 +23,7 @@ msgstr "<strong>Descuento</strong>"
 #. module: stock_picking_report_valued
 #: model_terms:ir.ui.view,arch_db:stock_picking_report_valued.valued_report_picking
 msgid "<strong>Subtotal</strong>"
-msgstr "<strong>Subtotal</strong>"
+msgstr ""
 
 #. module: stock_picking_report_valued
 #: model_terms:ir.ui.view,arch_db:stock_picking_report_valued.valued_report_picking
@@ -35,7 +33,7 @@ msgstr "<strong>Impuestos</strong>"
 #. module: stock_picking_report_valued
 #: model_terms:ir.ui.view,arch_db:stock_picking_report_valued.valued_report_picking
 msgid "<strong>Total</strong>"
-msgstr "<strong>Total</strong>"
+msgstr ""
 
 #. module: stock_picking_report_valued
 #: model_terms:ir.ui.view,arch_db:stock_picking_report_valued.valued_report_picking
@@ -48,6 +46,21 @@ msgid "<strong>Untaxed Amount</strong>"
 msgstr "<strong>Base imponible</strong>"
 
 #. module: stock_picking_report_valued
+#: model:ir.model,name:stock_picking_report_valued.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: stock_picking_report_valued
+#: model:ir.model,name:stock_picking_report_valued.model_res_config_settings
+msgid "Config Settings"
+msgstr "Ajustes de configuración"
+
+#. module: stock_picking_report_valued
+#: model_terms:ir.ui.view,arch_db:stock_picking_report_valued.view_res_config_settings_form
+msgid "Configure if the picking valued should be printed"
+msgstr ""
+
+#. module: stock_picking_report_valued
 #: model:ir.model,name:stock_picking_report_valued.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
@@ -58,9 +71,21 @@ msgid "Currency"
 msgstr "Moneda"
 
 #. module: stock_picking_report_valued
+#: model:ir.model.fields,field_description:stock_picking_report_valued.field_res_company__display_valued_in_picking
+#: model:ir.model.fields,field_description:stock_picking_report_valued.field_res_config_settings__display_valued_in_picking
+#: model:ir.model.fields,field_description:stock_picking_report_valued.field_stock_picking__company_display_valued_in_picking
+msgid "Display Valued In Picking"
+msgstr ""
+
+#. module: stock_picking_report_valued
 #: model:ir.model.fields,field_description:stock_picking_report_valued.field_stock_move_line__sale_price_subtotal
 msgid "Price subtotal"
 msgstr "Subtotal"
+
+#. module: stock_picking_report_valued
+#: model_terms:ir.ui.view,arch_db:stock_picking_report_valued.view_res_config_settings_form
+msgid "Print Picking Valued"
+msgstr ""
 
 #. module: stock_picking_report_valued
 #: model:ir.model,name:stock_picking_report_valued.model_stock_move_line
@@ -107,7 +132,7 @@ msgstr "Impuestos"
 #: model:ir.model.fields,field_description:stock_picking_report_valued.field_stock_move_line__sale_price_total
 #: model:ir.model.fields,field_description:stock_picking_report_valued.field_stock_picking__amount_total
 msgid "Total"
-msgstr "Total"
+msgstr ""
 
 #. module: stock_picking_report_valued
 #: model:ir.model,name:stock_picking_report_valued.model_stock_picking
@@ -120,33 +145,18 @@ msgid "Untaxed Amount"
 msgstr "Base imponible"
 
 #. module: stock_picking_report_valued
+#: model:ir.model.fields,field_description:stock_picking_report_valued.field_stock_picking__valued
+msgid "Valued"
+msgstr "Albarán valorado"
+
+#. module: stock_picking_report_valued
 #: model:ir.model.fields,field_description:stock_picking_report_valued.field_res_partner__valued_picking
 #: model:ir.model.fields,field_description:stock_picking_report_valued.field_res_users__valued_picking
-#: model:ir.model.fields,field_description:stock_picking_report_valued.field_stock_picking__valued
 msgid "Valued Picking"
 msgstr "Albarán valorado"
 
 #. module: stock_picking_report_valued
 #: model:ir.model.fields,help:stock_picking_report_valued.field_res_partner__valued_picking
 #: model:ir.model.fields,help:stock_picking_report_valued.field_res_users__valued_picking
-#: model:ir.model.fields,help:stock_picking_report_valued.field_stock_picking__valued
 msgid "You can select which partners have valued pickings"
 msgstr "Puede seleccionar qué empresas tienen albarán valorado"
-
-#~ msgid "<strong>Qty Reserved</strong>"
-#~ msgstr "<strong>Cantidad Reservada</strong>"
-
-#~ msgid "Sale price unit"
-#~ msgstr "Precio venta"
-
-#~ msgid "Packing Operation"
-#~ msgstr "Operación de empaquetado"
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"
-
-#~ msgid "Website Messages"
-#~ msgstr "Mensajes del sitio web"
-
-#~ msgid "Website communication history"
-#~ msgstr "Historial de comunicaciones del sitio web"

--- a/stock_picking_report_valued/models/__init__.py
+++ b/stock_picking_report_valued/models/__init__.py
@@ -1,3 +1,4 @@
 from . import res_partner
+from . import res_config_settings
 from . import stock_move_line
 from . import stock_picking

--- a/stock_picking_report_valued/models/res_config_settings.py
+++ b/stock_picking_report_valued/models/res_config_settings.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    display_valued_in_picking = fields.Boolean(default=False)
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    display_valued_in_picking = fields.Boolean(
+        related="company_id.display_valued_in_picking", readonly=False
+    )

--- a/stock_picking_report_valued/models/stock_picking.py
+++ b/stock_picking_report_valued/models/stock_picking.py
@@ -10,7 +10,12 @@ from odoo import fields, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    valued = fields.Boolean(related="partner_id.valued_picking", readonly=True)
+    valued = fields.Boolean(related="partner_id.valued_picking", readonly=False)
+    company_display_valued_in_picking = fields.Boolean(
+        related="company_id.display_valued_in_picking",
+        depends=["company_id"],
+    )
+
     currency_id = fields.Many2one(
         related="sale_id.currency_id",
         readonly=True,

--- a/stock_picking_report_valued/readme/CONFIGURE.md
+++ b/stock_picking_report_valued/readme/CONFIGURE.md
@@ -1,3 +1,11 @@
-1.  Go to *Sales \> Orders \> Customers \> (select one of your choice) \> Sales &
-    Purchases*.
-2.  Set *Valued picking* field on.
+To configure valued pickings at partner level:
+
+1.  Go to _Sales \> Orders \> Customers \> (select one of your choice) \> Sales &
+    Purchases_.
+2.  Set _Valued picking_ field on.
+
+To enable the valued picking option directly on picking forms:
+
+1. Go to _Inventory > Configuration > Settings_.
+2. Check the option _Display Valued Picking_ in the Delivery section.
+3. Click on _Save_.

--- a/stock_picking_report_valued/readme/CONTRIBUTORS.md
+++ b/stock_picking_report_valued/readme/CONTRIBUTORS.md
@@ -16,3 +16,5 @@
   - Miguel Gandia \<<miguel@studio73.es>\>
 - [Trobz](https://trobz.com):
   - Nguyen Minh Chien \<<chien@trobz.com>\>
+- [Binhex](https://binhex.cloud)
+  - Antonio Ruban \<<antoniodavid8@gmail.com>\>

--- a/stock_picking_report_valued/readme/DESCRIPTION.md
+++ b/stock_picking_report_valued/readme/DESCRIPTION.md
@@ -1,4 +1,7 @@
-Add amount information to Delivery Slip report. You can select at
-partner level if picking list report must be valued or not. If the
-picking is done it's valued with quantity done, otherwise the picking is
-valued with reserved quantity.
+Add amount information to Delivery Slip report. You can select at partner level if
+picking list report must be valued or not. If the picking is done it's valued with
+quantity done, otherwise the picking is valued with reserved quantity.
+
+Additionally, you can configure each individual picking to be valued or not, regardless
+of the partner's configuration. This allows for more flexibility when generating
+delivery slips for different purposes or recipients.

--- a/stock_picking_report_valued/readme/USAGE.md
+++ b/stock_picking_report_valued/readme/USAGE.md
@@ -1,7 +1,13 @@
 To get the stock picking valued report:
 
-1.  Create a Sales Order with storable products a *Valued picking* able
-    customer.
+1.  Create a Sales Order with storable products a _Valued picking_ able customer.
 2.  Confirm the Sale Order.
-3.  Click on *Delivery* stat button.
-4.  Go to *Print \> Delivery Slip*.
+3.  Click on _Delivery_ stat button.
+4.  Go to _Print \> Delivery Slip_.
+
+Alternatively, you can configure the valued report option directly on the picking:
+
+1.  Open a stock picking.
+2.  Check or uncheck the _Valued_ checkbox (only visible if the company setting is
+    enabled).
+3.  Go to _Print \> Delivery Slip_ to get the report with or without values accordingly.

--- a/stock_picking_report_valued/static/description/index.html
+++ b/stock_picking_report_valued/static/description/index.html
@@ -374,6 +374,10 @@ ul.auto-toc {
 partner level if picking list report must be valued or not. If the
 picking is done it’s valued with quantity done, otherwise the picking is
 valued with reserved quantity.</p>
+<p>Additionally, you can configure each individual picking to be valued or
+not, regardless of the partner’s configuration. This allows for more
+flexibility when generating delivery slips for different purposes or
+recipients.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -392,10 +396,17 @@ valued with reserved quantity.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>To configure valued pickings at partner level:</p>
 <ol class="arabic simple">
 <li>Go to <em>Sales &gt; Orders &gt; Customers &gt; (select one of your choice) &gt;
 Sales &amp; Purchases</em>.</li>
 <li>Set <em>Valued picking</em> field on.</li>
+</ol>
+<p>To enable the valued picking option directly on picking forms:</p>
+<ol class="arabic simple">
+<li>Go to <em>Inventory &gt; Configuration &gt; Settings</em>.</li>
+<li>Check the option <em>Display Valued Picking</em> in the Delivery section.</li>
+<li>Click on <em>Save</em>.</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -407,6 +418,15 @@ customer.</li>
 <li>Confirm the Sale Order.</li>
 <li>Click on <em>Delivery</em> stat button.</li>
 <li>Go to <em>Print &gt; Delivery Slip</em>.</li>
+</ol>
+<p>Alternatively, you can configure the valued report option directly on
+the picking:</p>
+<ol class="arabic simple">
+<li>Open a stock picking.</li>
+<li>Check or uncheck the <em>Valued</em> checkbox (only visible if the company
+setting is enabled).</li>
+<li>Go to <em>Print &gt; Delivery Slip</em> to get the report with or without
+values accordingly.</li>
 </ol>
 </div>
 <div class="section" id="known-issues-roadmap">
@@ -468,6 +488,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://trobz.com">Trobz</a>:<ul>
 <li>Nguyen Minh Chien &lt;<a class="reference external" href="mailto:chien&#64;trobz.com">chien&#64;trobz.com</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://binhex.cloud">Binhex</a><ul>
+<li>Antonio Ruban &lt;<a class="reference external" href="mailto:antoniodavid8&#64;gmail.com">antoniodavid8&#64;gmail.com</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/stock_picking_report_valued/views/res_config_settings_views.xml
+++ b/stock_picking_report_valued/views/res_config_settings_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!-- View res.config.settings form -->
+    <record id="view_res_config_settings_form" model="ir.ui.view">
+        <field name="name">view.res.config.settings.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@id='reception_report']" position="after">
+                <setting
+                    id="display_valued_in_picking"
+                    string="Print Picking Valued"
+                    help="Configure if the picking valued should be printed"
+                    groups="stock.group_stock_manager"
+                >
+                    <field name="display_valued_in_picking" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/stock_picking_report_valued/views/stock_picking_views.xml
+++ b/stock_picking_report_valued/views/stock_picking_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!-- View stock.picking form -->
+    <record id="view_stock_picking_form" model="ir.ui.view">
+        <field name="name">view.stock.picking.form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='origin']" position="after">
+                <field name="company_display_valued_in_picking" invisible="1" />
+                <field
+                    name="valued"
+                    invisible="not company_display_valued_in_picking"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
@BinhexTeam T13181

**Issue**
Currently, a checkbox must be activated on the contact record, which determines the type of report that can be downloaded. This is not ideal for the client, as multiple delivery orders are generated daily, and constantly modifying the configuration in the contact's record to select the report type to download is impractical. This complicates the efficient management of documents that need to be delivered to agencies or carriers.

**Solution**
The functionality of this module allows, through a general configuration, the option to decide whether to print the valued picking on the same picking, rather than as it was before, on the same partner

