### PR TITLE
[14.0][IMP] stock_quant_history

### DIFF
--- a/stock_quant_history/README.rst
+++ b/stock_quant_history/README.rst
@@ -37,6 +37,8 @@ are present in the database.
 
 Next snapshot is computed based on the previous snapshot present in the database.
 
+Once a snapshot has been taken, every locked and done picking won't be able to unlock
+to avoid incoherent stock history.
 
 **Table of contents**
 
@@ -107,6 +109,7 @@ Authors
 ~~~~~~~
 
 * Pierre Verkest <pierreverkest84@gmail.com>
+* Stéphane Mangin <stephane.mangin@foodles.com>
 
 Maintainers
 ~~~~~~~~~~~
@@ -124,10 +127,13 @@ promote its widespread use.
 .. |maintainer-petrus-v| image:: https://github.com/petrus-v.png?size=40px
     :target: https://github.com/petrus-v
     :alt: petrus-v
+.. |maintainer-StephaneMangin| image:: https://github.com/StephaneMangin.png?size=40px
+    :target: https://github.com/StephaneMangin
+    :alt: StephaneMangin
 
-Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-petrus-v| 
+|maintainer-petrus-v| |maintainer-StephaneMangin| 
 
 This module is part of the `OCA/stock-logistics-reporting <https://github.com/OCA/stock-logistics-reporting/tree/14.0/stock_quant_history>`_ project on GitHub.
 

--- a/stock_quant_history/__manifest__.py
+++ b/stock_quant_history/__manifest__.py
@@ -4,17 +4,20 @@
 {
     "name": "Stock Quant History",
     "summary": "Re-generate stock quants for given date",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "license": "AGPL-3",
-    "author": "Pierre Verkest <pierreverkest84@gmail.com>, Odoo Community Association (OCA)",
+    "author": "Pierre Verkest <pierreverkest84@gmail.com>, Stéphane Mangin "
+    "<stephane.mangin@foodles.com>, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-reporting",
     "depends": ["stock"],
     "maintainers": [
         "petrus-v",
+        "StephaneMangin",
     ],
     "data": [
         "security/ir.model.access.csv",
         "views/stock-quant-history-snapshot.xml",
         "views/stock-quant-history.xml",
+        "views/res_config_settings_views.xml",
     ],
 }

--- a/stock_quant_history/i18n/fr.po
+++ b/stock_quant_history/i18n/fr.po
@@ -279,3 +279,9 @@ msgid "stock.quant.history generation configuration model"
 msgstr ""
 "Cliché de stock: Modèle de configuration pour la génération des ligne de "
 "stock.quant.history"
+
+#. module: stock_quant_history
+#: code:addons/stock_quant_history/models/stock_picking.py:0
+#, python-format
+msgid "You cannot unlock '%s' as stock histories exists:%s%s."
+msgstr "Vous ne pouvez pas déverrouiller '%s' car il existe un ou plusieurs historiques de stock associés:%s%s."

--- a/stock_quant_history/i18n/it.po
+++ b/stock_quant_history/i18n/it.po
@@ -271,3 +271,9 @@ msgstr ""
 #: model:ir.model,name:stock_quant_history.model_stock_quant_history_snapshot
 msgid "stock.quant.history generation configuration model"
 msgstr ""
+
+#. module: stock_quant_history
+#: code:addons/stock_quant_history/models/stock_picking.py:0
+#, python-format
+msgid "You cannot unlock '%s' as stock histories exists:%s%s."
+msgstr ""

--- a/stock_quant_history/i18n/stock_quant_history.pot
+++ b/stock_quant_history/i18n/stock_quant_history.pot
@@ -270,3 +270,9 @@ msgstr ""
 #: model:ir.model,name:stock_quant_history.model_stock_quant_history_snapshot
 msgid "stock.quant.history generation configuration model"
 msgstr ""
+
+#. module: stock_quant_history
+#: code:addons/stock_quant_history/models/stock_picking.py:0
+#, python-format
+msgid "You cannot unlock '%s' as stock histories exists:%s%s."
+msgstr ""

--- a/stock_quant_history/models/__init__.py
+++ b/stock_quant_history/models/__init__.py
@@ -1,2 +1,5 @@
-from . import stock_quant_history_snapshot
+from . import res_company
+from . import res_config_settings
+from . import stock_picking
 from . import stock_quant_history
+from . import stock_quant_history_snapshot

--- a/stock_quant_history/models/res_company.py
+++ b/stock_quant_history/models/res_company.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Foodles (http://www.foodles.co).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Company(models.Model):
+    _inherit = "res.company"
+    _check_company_auto = True
+
+    stock_history_snapshot_auto_locks_picking = fields.Boolean(
+        string="Auto lock picking on snapshot",
+        help="When a stock quant history snapshot is generated, "
+        "automatically locks all done pickings that are related to the snapshot.",
+        default=True,
+        groups="stock.group_stock_manager",
+    )

--- a/stock_quant_history/models/res_config_settings.py
+++ b/stock_quant_history/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Foodles (http://www.foodles.co).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    stock_history_snapshot_auto_locks_picking = fields.Boolean(
+        related="company_id.stock_history_snapshot_auto_locks_picking",
+        readonly=False,
+        groups="stock.group_stock_manager",
+    )

--- a/stock_quant_history/models/stock_picking.py
+++ b/stock_quant_history/models/stock_picking.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Foodles (https://www.foodles.co/).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, models
+from odoo.exceptions import ValidationError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def get_stock_quant_history(self):
+        """Get the last stock quant history related to this picking.
+        The picking must be done.
+        :return: stock.quant.history recordset"""
+        self.ensure_one()
+        history_model = self.env["stock.quant.history"]
+        if self.state == "done" and self.date_done:
+            domain = [
+                ("inventory_date", ">=", self.date_done),
+                ("product_id", "in", self.move_line_ids.mapped("product_id").ids),
+                ("lot_id", "in", self.move_line_ids.mapped("lot_id").ids),
+            ]
+            return history_model.search(domain)
+        return history_model
+
+    def action_toggle_is_locked(self):
+        # Ensure the picking is allowed to be unlocked before toggling the lock status.
+        self.check_unlock_allowed()
+        return super().action_toggle_is_locked()
+
+    def check_unlock_allowed(self):
+        """Check if the picking can be unlocked.
+        :return: True if the picking can be unlocked
+        :raises ValidationError: if not allowed to unlock"""
+        separator = "\n - "
+        self.ensure_one()
+        if self.is_locked:
+            history_lines = self.get_stock_quant_history()
+            if history_lines.exists():
+                snapshot_text = separator.join(
+                    history_lines.mapped("snapshot_id").mapped("display_name")
+                )
+                raise ValidationError(
+                    _("You cannot unlock '%s' as stock histories exists:%s%s.")
+                    % (self.display_name, separator, snapshot_text)
+                )
+        return True
+
+    def write(self, vals):
+        # Constraint the lock status to avoid unlocking a record when a related quant
+        # history exists.
+        # An unlock action is propagated
+        if "is_locked" in vals and not vals.get("is_locked"):
+            # Reducing to locked status and done picking
+            for picking in self.filtered(
+                lambda pick: pick.is_locked and pick.state == "done" and pick.date_done
+            ):
+                picking.check_unlock_allowed()
+        return super().write(vals)

--- a/stock_quant_history/models/stock_quant_history_snapshot.py
+++ b/stock_quant_history/models/stock_quant_history_snapshot.py
@@ -151,38 +151,34 @@ class StockQuantHistorySnapshot(models.Model):
         _logger.info(
             "Apply %s stock.move.line since previous snapshot", len(stock_move_lines)
         )
+        pickings = self.env["stock.picking"]
         ignored_location_usage = self._ignored_location_usage()
         for move_line in stock_move_lines:
+            quantity = move_line.product_uom_id._compute_quantity(
+                move_line.qty_done, move_line.product_id.uom_id
+            )
             if move_line.location_id.usage not in ignored_location_usage:
-                quant_history[
+                quant_copy = quant_history[
                     (move_line.product_id, move_line.lot_id, move_line.location_id)
-                ].quantity = tools.float_round(
-                    quant_history[
-                        (move_line.product_id, move_line.lot_id, move_line.location_id)
-                    ].quantity
-                    - move_line.product_uom_id._compute_quantity(
-                        move_line.qty_done, move_line.product_id.uom_id
-                    ),
+                ]
+                quant_copy.quantity = tools.float_round(
+                    quant_copy.quantity - quantity,
                     precision_rounding=move_line.product_id.uom_id.rounding,
                 )
-
             if move_line.location_dest_id.usage not in ignored_location_usage:
-                quant_history[
+                quant_copy = quant_history[
                     (move_line.product_id, move_line.lot_id, move_line.location_dest_id)
-                ].quantity = tools.float_round(
-                    quant_history[
-                        (
-                            move_line.product_id,
-                            move_line.lot_id,
-                            move_line.location_dest_id,
-                        )
-                    ].quantity
-                    + move_line.product_uom_id._compute_quantity(
-                        move_line.qty_done, move_line.product_id.uom_id
-                    ),
+                ]
+                quant_copy.quantity = tools.float_round(
+                    quant_copy.quantity + quantity,
                     precision_rounding=move_line.product_id.uom_id.rounding,
                 )
+            pickings |= move_line.picking_id
 
+        # Lock all related pickings
+        if self.env.company.stock_history_snapshot_auto_locks_picking:
+            _logger.info(f"Locking {len(pickings)} related pickings")
+            pickings.sudo().write({"is_locked": True})
         # remove line with zero to save same disk space
         # avoid loop with direct SQL query
         _logger.info("Remove useless stock_quant_history with quantity == 0")

--- a/stock_quant_history/readme/CONSTRIBUTORS.rst
+++ b/stock_quant_history/readme/CONSTRIBUTORS.rst
@@ -1,1 +1,3 @@
-* Pierre Verkest <pierreverkest84@gmail.com>
+* `Pierre Verkest <pierreverkest84@gmail.com>`_
+* `Foodles <https://www.foodles.com>`_
+  * `Stéphane Mangin <stephane.mangin@foodles.co>`_

--- a/stock_quant_history/readme/DESCRIPTION.rst
+++ b/stock_quant_history/readme/DESCRIPTION.rst
@@ -7,3 +7,5 @@ are present in the database.
 
 Next snapshot is computed based on the previous snapshot present in the database.
 
+Once a snapshot has been taken, every locked and done picking won't be able to unlock
+to avoid incoherent stock history.

--- a/stock_quant_history/static/description/index.html
+++ b/stock_quant_history/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -375,6 +375,8 @@ ul.auto-toc {
 <p>To generate the first snapshot this module assume all <cite>stock.move.line</cite>
 are present in the database.</p>
 <p>Next snapshot is computed based on the previous snapshot present in the database.</p>
+<p>Once a snapshot has been taken, every locked and done picking won’t be able to unlock
+to avoid incoherent stock history.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -463,17 +465,20 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-10">Authors</a></h2>
 <ul class="simple">
 <li>Pierre Verkest &lt;<a class="reference external" href="mailto:pierreverkest84&#64;gmail.com">pierreverkest84&#64;gmail.com</a>&gt;</li>
+<li>Stéphane Mangin &lt;<a class="reference external" href="mailto:stephane.mangin&#64;foodles.com">stephane.mangin&#64;foodles.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/petrus-v"><img alt="petrus-v" src="https://github.com/petrus-v.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/petrus-v"><img alt="petrus-v" src="https://github.com/petrus-v.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/StephaneMangin"><img alt="StephaneMangin" src="https://github.com/StephaneMangin.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/stock-logistics-reporting/tree/14.0/stock_quant_history">OCA/stock-logistics-reporting</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/stock_quant_history/tests/__init__.py
+++ b/stock_quant_history/tests/__init__.py
@@ -1,1 +1,3 @@
+from . import common
 from . import test_stock_quant_history
+from . import test_stock_picking

--- a/stock_quant_history/tests/common.py
+++ b/stock_quant_history/tests/common.py
@@ -1,0 +1,147 @@
+# Copyright 2025 Foodles (https://www.foodles.co/).
+# @author Pierre Verkest <pierreverkest84@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from collections import defaultdict
+
+from odoo import fields
+from odoo.tests import SavepointCase
+
+
+class TestStockQuantHistoryCommon(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                test_queue_job_no_delay=True,  # no jobs thanks
+            )
+        )
+
+        cls.stock_history_now = cls.env["stock.quant.history.snapshot"].create(
+            {
+                "inventory_date": fields.Datetime.now(),
+            }
+        )
+
+        cls.stock_manager_user = cls.env["res.users"].create(
+            {
+                "name": "foo",
+                "login": "stock_manager",
+                "email": "foo@bar.com",
+                "lang": "en_US",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        (
+                            cls.env.ref("base.group_user")
+                            | cls.env.ref("stock.group_stock_manager")
+                        ).ids,
+                    )
+                ],
+            }
+        )
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.location = cls.warehouse.lot_stock_id
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "test",
+                "type": "product",
+                "tracking": "lot",
+            }
+        )
+        cls.lot = cls.env["stock.production.lot"].create(
+            {
+                "name": "lot test",
+                "product_id": cls.product.id,
+                "company_id": cls.warehouse.company_id.id,
+            }
+        )
+        cls.product_consu = cls.env["product.product"].create(
+            {
+                "name": "test",
+                "type": "consu",
+            }
+        )
+
+    def _update_product_stock(self, qty, lot=None, location=None, uom=None):
+        if lot is None:
+            lot = self.lot
+        if not location:
+            location = self.location
+        if not uom:
+            uom = self.product.uom_id
+        inventory = self.env["stock.inventory"].create(
+            {
+                "name": "Test Inventory",
+                "product_ids": [(6, 0, self.product.ids)],
+                "state": "confirm",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_qty": qty,
+                            "location_id": location.id,
+                            "product_id": self.product.id,
+                            "product_uom_id": uom.id,
+                            "prod_lot_id": lot.id,
+                        },
+                    )
+                ],
+            }
+        )
+        inventory.action_validate()
+
+    @classmethod
+    def quants_quantity_group_by(cls, recordset, key):
+        """inspired from sale_product_pack PR: gh:oca/product-pack/pull/159"""
+        groups = defaultdict(lambda: 0)
+        for elem in recordset:
+            groups[key(elem)] += elem.quantity
+        return groups
+
+    def assertQuantCompare(self, quants, expected_quants):
+        """works either with stock.quant or stock.quants.history"""
+
+        def group_key(quant):
+            return quant.product_id, quant.lot_id, quant.location_id
+
+        grouped_quants = self.quants_quantity_group_by(quants, group_key)
+        grouped_expected_quants = self.quants_quantity_group_by(
+            expected_quants, group_key
+        )
+        errors1 = []
+        errors2 = []
+        ok = []
+        for key, quantity in grouped_quants.items():
+            if grouped_expected_quants[key] != quantity:
+                errors1.append(
+                    f"got {quantity} != Expected {grouped_expected_quants[key]} for"
+                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
+                )
+            else:
+                ok.append(
+                    f"{grouped_expected_quants[key]} for "
+                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
+                    f"is the same {quantity} !"
+                )
+
+        for key, quantity in grouped_expected_quants.items():
+            if grouped_quants[key] != quantity:
+                errors2.append(
+                    f"got {grouped_quants[key]} != Expected {quantity} for "
+                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
+                )
+        self.assertEqual(
+            len(errors1) + len(errors2),
+            0,
+            "Following diff detected:\n"
+            "\n".join(errors1)
+            + "\n or/and \n "
+            + "\n".join(errors2)
+            + "\n\nOK records:\n"
+            + "\n".join(ok),
+        )

--- a/stock_quant_history/tests/test_stock_picking.py
+++ b/stock_quant_history/tests/test_stock_picking.py
@@ -1,0 +1,139 @@
+# Copyright 2025 Foodles (https://www.foodles.co/).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from freezegun import freeze_time
+from setuptools.config._validate_pyproject import ValidationError
+
+from odoo.tests import tagged, users
+
+from . import common
+
+
+@tagged("post_install", "-at_install")
+@freeze_time("2022-06-01 12:00+00")
+class TestStockPickingLock(common.TestStockQuantHistoryCommon):
+    """Test the lock constraint functionality on picking.
+          ┌────────────────────────┐
+          │(unlock, no history) TC3│
+          ▼                        │
+    ┌───────────┐            ┌─────┴─────┐
+    │ Unlocked  ├───────────►│  Locked   │
+    └───────────┘ (lock) TC1 └─────┬─────┘
+                                   │
+    (unlock, history exists) TC2   ▼
+                             ┌───────────┐
+                             │ Exception │
+                             └───────────┘
+    """
+
+    def setUp(self):
+        super().setUp()
+        customer_location = self.env.ref("stock.stock_location_customers")
+        # prepare a snapshot
+        self.picking = self.env["stock.picking"].create(
+            {
+                "name": "Test Picking",
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "location_id": self.location.id,
+                "location_dest_id": customer_location.id,
+                "is_locked": False,
+            }
+        )
+        self.move_line = self.env["stock.move.line"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.location.id,
+                "location_dest_id": customer_location.id,
+                "picking_id": self.picking.id,
+                "product_uom_id": self.product.uom_id.id,
+                "product_uom_qty": 1,
+                "lot_id": self.lot.id,
+            }
+        )
+
+    @users("stock_manager")
+    def test1_lock_unlock_without_history(self):
+        """Test the lock functionality."""
+        # Assign and confirm the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        # This picking should be unlocked (no changes on standard behavior)
+        self.picking.write({"is_locked": True})
+        self.assertTrue(self.picking.is_locked, "The picking should be locked.")
+        self.picking.write({"is_locked": False})
+        self.assertFalse(
+            self.picking.is_locked, "The picking should be unlocked after toggling."
+        )
+
+    @users("stock_manager")
+    def test2_unlock_with_history(self):
+        """Test the unlock functionality with history."""
+        # Validate and finish the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.write({"is_locked": True})
+        self.assertTrue(self.picking.is_locked, "The picking should be locked.")
+        # Create a snapshot including this picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        # Try to unlock the picking
+        with self.assertRaises(ValidationError):
+            self.picking.write({"is_locked": False})
+
+    @users("stock_manager")
+    def test3_unlock_with_past_history(self):
+        """Test the unlock functionality without history."""
+        # Create a snapshot before confirming the picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        self.assertIn(
+            self.lot,
+            self.stock_history_now.stock_quant_history_ids.mapped("lot_id"),
+            "The snapshot should have the lot of the move line.",
+        )
+        # Validate and finish the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.write({"is_locked": True})
+        self.assertTrue(self.picking.is_locked, "The picking should be locked.")
+        # This picking should be unlocked (no changes on standard behavior)
+        self.picking.write({"is_locked": False})
+        self.assertFalse(
+            self.picking.is_locked, "The picking should be unlocked after toggling."
+        )
+
+    @users("stock_manager")
+    def test_lock_done_picking_on_snapshot_creation_with_option(self):
+        """Test that the picking is locked when a snapshot is created."""
+        self.env.company.stock_history_snapshot_auto_locks_picking = True
+        # Validate and finish the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        # Create a snapshot including this picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        # The picking should be locked after the snapshot creation
+        self.assertTrue(
+            self.picking.is_locked, "The picking should be locked after snapshot."
+        )
+
+    @users("stock_manager")
+    def test_lock_done_picking_on_snapshot_creation_no_option(self):
+        """Test that the picking is not locked when a snapshot is created without the
+        option set (default behavior)."""
+        # Validate and finish the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.stock_history_now.action_generate_stock_quant_history()
+        # The picking should remain unlocked after the snapshot creation
+        self.assertFalse(
+            self.picking.is_locked, "The picking should remain unlocked after snapshot."
+        )
+
+    @users("stock_manager")
+    def test_unlocked_pending_picking_on_snapshot_creation(self):
+        """Test that the picking remains unlocked when a snapshot is created."""
+        # Create a snapshot including this picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        # The picking should remain unlocked after the snapshot creation
+        self.assertFalse(
+            self.picking.is_locked, "The picking should remain unlocked after snapshot."
+        )

--- a/stock_quant_history/tests/test_stock_quant_history.py
+++ b/stock_quant_history/tests/test_stock_quant_history.py
@@ -1,150 +1,17 @@
-from collections import defaultdict
+# Copyright 2025 Foodles (https://www.foodles.co/).
+# @author Pierre Verkest <pierreverkest84@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import AccessError
-from odoo.tests import SavepointCase, users
+from odoo.tests import users
+
+from . import common
 
 
-class TestStockQuantHistory(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(
-            context=dict(
-                cls.env.context,
-                test_queue_job_no_delay=True,  # no jobs thanks
-            )
-        )
-
-        cls.stock_history_now = cls.env["stock.quant.history.snapshot"].create(
-            {
-                "inventory_date": fields.Datetime.now(),
-            }
-        )
-
-        cls.stock_manager_user = cls.env["res.users"].create(
-            {
-                "name": "foo",
-                "login": "stock_manager",
-                "email": "foo@bar.com",
-                "lang": "en_US",
-                "groups_id": [
-                    (
-                        6,
-                        0,
-                        (
-                            cls.env.ref("base.group_user")
-                            | cls.env.ref("stock.group_stock_manager")
-                        ).ids,
-                    )
-                ],
-            }
-        )
-        cls.warehouse = cls.env.ref("stock.warehouse0")
-        cls.location = cls.warehouse.lot_stock_id
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "test",
-                "type": "product",
-                "tracking": "lot",
-            }
-        )
-        cls.lot = cls.env["stock.production.lot"].create(
-            {
-                "name": "lot test",
-                "product_id": cls.product.id,
-                "company_id": cls.warehouse.company_id.id,
-            }
-        )
-        cls.product_consu = cls.env["product.product"].create(
-            {
-                "name": "test",
-                "type": "consu",
-            }
-        )
-
-    def _update_product_stock(self, qty, lot=None, location=None, uom=None):
-        if lot is None:
-            lot = self.lot
-        if not location:
-            location = self.location
-        if not uom:
-            uom = self.product.uom_id
-        inventory = self.env["stock.inventory"].create(
-            {
-                "name": "Test Inventory",
-                "product_ids": [(6, 0, self.product.ids)],
-                "state": "confirm",
-                "line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "product_qty": qty,
-                            "location_id": location.id,
-                            "product_id": self.product.id,
-                            "product_uom_id": uom.id,
-                            "prod_lot_id": lot.id,
-                        },
-                    )
-                ],
-            }
-        )
-        inventory.action_validate()
-
-    @classmethod
-    def quants_quantity_group_by(cls, recordset, key):
-        """inspired from sale_product_pack PR: gh:oca/product-pack/pull/159"""
-        groups = defaultdict(lambda: 0)
-        for elem in recordset:
-            groups[key(elem)] += elem.quantity
-        return groups
-
-    def assertQuantCompare(self, quants, expected_quants):
-        """works either with stock.quant or stock.quants.history"""
-
-        def group_key(quant):
-            return quant.product_id, quant.lot_id, quant.location_id
-
-        grouped_quants = self.quants_quantity_group_by(quants, group_key)
-        grouped_expected_quants = self.quants_quantity_group_by(
-            expected_quants, group_key
-        )
-        errors1 = []
-        errors2 = []
-        ok = []
-        for key, quantity in grouped_quants.items():
-            if grouped_expected_quants[key] != quantity:
-                errors1.append(
-                    f"got {quantity} != Expected {grouped_expected_quants[key]} for"
-                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
-                )
-            else:
-                ok.append(
-                    f"{grouped_expected_quants[key]} for "
-                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
-                    f"is the same {quantity} !"
-                )
-
-        for key, quantity in grouped_expected_quants.items():
-            if grouped_quants[key] != quantity:
-                errors2.append(
-                    f"got {grouped_quants[key]} != Expected {quantity} for "
-                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
-                )
-        self.assertEqual(
-            len(errors1) + len(errors2),
-            0,
-            "Following diff detected:\n"
-            "\n".join(errors1)
-            + "\n or/and \n "
-            + "\n".join(errors2)
-            + "\n\nOK records:\n"
-            + "\n".join(ok),
-        )
-
+class TestStockQuantHistory(common.TestStockQuantHistoryCommon):
     def test_compare_quant(self):
         self.stock_history_now.action_generate_stock_quant_history()
         self.assertQuantCompare(

--- a/stock_quant_history/views/res_config_settings_views.xml
+++ b/stock_quant_history/views/res_config_settings_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Foodles (http://www.foodles.co).
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">
+            Stock settings: auto lock picking on snapshot creation
+        </field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div id="warning_info" position="after">
+                <div class="col-12 col-lg-6 o_setting_box" id="snapshot_autolock">
+                    <div class="o_setting_left_pane">
+                        <field name="stock_history_snapshot_auto_locks_picking" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="stock_history_snapshot_auto_locks_picking" />
+                        <div class="text-muted">
+                            When a stock quant history snapshot is generated,
+                            automatically locks all done pickings that are related to
+                            the snapshot
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add a constraint on locked picking while an history snapshot is generated.

Included a light refactoring of tests suites.

Propagated to [17.0 PR](https://github.com/OCA/stock-logistics-reporting/pull/415)