### PR TITLE
[17.0][IMP] stock_quant_history

### DIFF
--- a/stock_quant_history/README.rst
+++ b/stock_quant_history/README.rst
@@ -39,6 +39,9 @@ are present in the database.
 Next snapshot is computed based on the previous snapshot present in the
 database.
 
+Once a snapshot has been taken, every locked and done picking won't be
+able to unlock to avoid incoherent stock history.
+
 **Table of contents**
 
 .. contents::
@@ -75,6 +78,12 @@ or
 - Go to: *Inventory / Reporting / History / Stock quants*
 - use different filters / group and views to make your analysis
 
+Avoid pickings lock automation on snapshot creation
+---------------------------------------------------
+
+- Go to: *Inventory / Configuration / Settings*
+- Uncheck the option *Auto lock picking on snapshot*
+
 Known issues / Roadmap
 ======================
 
@@ -108,6 +117,8 @@ Authors
 -------
 
 * Pierre Verkest <pierreverkest84@gmail.com>
+* Foodles
+* Stéphane Mangin <stephane.mangin@foodles.com>
 
 Maintainers
 -----------
@@ -125,10 +136,13 @@ promote its widespread use.
 .. |maintainer-petrus-v| image:: https://github.com/petrus-v.png?size=40px
     :target: https://github.com/petrus-v
     :alt: petrus-v
+.. |maintainer-StephaneMangin| image:: https://github.com/StephaneMangin.png?size=40px
+    :target: https://github.com/StephaneMangin
+    :alt: StephaneMangin
 
-Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-petrus-v| 
+|maintainer-petrus-v| |maintainer-StephaneMangin| 
 
 This module is part of the `OCA/stock-logistics-reporting <https://github.com/OCA/stock-logistics-reporting/tree/17.0/stock_quant_history>`_ project on GitHub.
 

--- a/stock_quant_history/__manifest__.py
+++ b/stock_quant_history/__manifest__.py
@@ -4,18 +4,20 @@
 {
     "name": "Stock Quant History",
     "summary": "Re-generate stock quants for given date",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.1.0",
     "license": "AGPL-3",
-    "author": "Pierre Verkest <pierreverkest84@gmail.com>, "
-    "Odoo Community Association (OCA)",
+    "author": "Pierre Verkest <pierreverkest84@gmail.com>, Foodles, Stéphane Mangin "
+    "<stephane.mangin@foodles.com>, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-reporting",
     "depends": ["stock"],
     "maintainers": [
         "petrus-v",
+        "StephaneMangin",
     ],
     "data": [
         "security/ir.model.access.csv",
         "views/stock-quant-history-snapshot.xml",
         "views/stock-quant-history.xml",
+        "views/res_config_settings_views.xml",
     ],
 }

--- a/stock_quant_history/i18n/fr.po
+++ b/stock_quant_history/i18n/fr.po
@@ -4,15 +4,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 08:37+0000\n"
+"PO-Revision-Date: 2025-06-03 10:39+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.6\n"
 
 #. module: stock_quant_history
 #: model_terms:ir.ui.view,arch_db:stock_quant_history.view_stock_quant_history_snapshot_form
@@ -20,9 +23,22 @@ msgid "<span>History details</span>"
 msgstr "<span>Stocks</span>"
 
 #. module: stock_quant_history
+#: model:ir.model.fields,field_description:stock_quant_history.field_res_company__stock_history_snapshot_auto_locks_picking
+#: model:ir.model.fields,field_description:stock_quant_history.field_res_config_settings__stock_history_snapshot_auto_locks_picking
+#: model_terms:ir.ui.view,arch_db:stock_quant_history.res_config_settings_view_form
+msgid "Auto lock picking on snapshot"
+msgstr ""
+"Verrouillage automatique des préparations à la création d’un historique de stock"
+
+#. module: stock_quant_history
 #: model:ir.model.fields,help:stock_quant_history.field_stock_quant_history_snapshot__previous_snapshot_id
 msgid "Base snapshot used to generate this snapshot"
 msgstr "Cliché de Stock de base utilisé pour la génération de ce cliché"
+
+#. module: stock_quant_history
+#: model:ir.model,name:stock_quant_history.model_res_company
+msgid "Companies"
+msgstr "Sociétés"
 
 #. module: stock_quant_history
 #: model:ir.model.fields,field_description:stock_quant_history.field_stock_quant_history__company_id
@@ -33,6 +49,11 @@ msgstr "Société"
 #: model:ir.actions.server,name:stock_quant_history.action_multi_related_stock_quant_history_tree_view
 msgid "Compare stocks"
 msgstr "Comparer les stocks des clichés sélectionnés"
+
+#. module: stock_quant_history
+#: model:ir.model,name:stock_quant_history.model_res_config_settings
+msgid "Config Settings"
+msgstr "Paramètres de configuration"
 
 #. module: stock_quant_history
 #: model_terms:ir.actions.act_window,help:stock_quant_history.action_stock_quant_history_snapshot
@@ -119,12 +140,6 @@ msgid "Inventory date"
 msgstr "Date du stock"
 
 #. module: stock_quant_history
-#: model:ir.model.fields,field_description:stock_quant_history.field_stock_quant_history____last_update
-#: model:ir.model.fields,field_description:stock_quant_history.field_stock_quant_history_snapshot____last_update
-msgid "Last Modified on"
-msgstr "Dernière modification le"
-
-#. module: stock_quant_history
 #: model:ir.model.fields,field_description:stock_quant_history.field_stock_quant_history__write_uid
 #: model:ir.model.fields,field_description:stock_quant_history.field_stock_quant_history_snapshot__write_uid
 msgid "Last Updated by"
@@ -156,7 +171,7 @@ msgstr "Emplacement et ses enfants"
 #. module: stock_quant_history
 #: model_terms:ir.ui.view,arch_db:stock_quant_history.view_stock_quant_history_search
 msgid "Lot"
-msgstr "Lot"
+msgstr ""
 
 #. module: stock_quant_history
 #: model:ir.model.fields,field_description:stock_quant_history.field_stock_quant_history__lot_id
@@ -194,12 +209,16 @@ msgstr ""
 "l'article"
 
 #. module: stock_quant_history
+#. odoo-python
+#: code:addons/stock_quant_history/models/stock_quant_history_snapshot.py:0
 #: model:ir.ui.menu,name:stock_quant_history.menu_action_stock_quant_history_snapshot
 #: model_terms:ir.ui.view,arch_db:stock_quant_history.view_stock_quant_history_search
+#, python-format
 msgid "Snapshot"
 msgstr "Cliché"
 
 #. module: stock_quant_history
+#. odoo-python
 #: code:addons/stock_quant_history/models/stock_quant_history_snapshot.py:0
 #, python-format
 msgid "Snapshot %s"
@@ -269,9 +288,36 @@ msgstr ""
 "l'était à cette date."
 
 #. module: stock_quant_history
+#: model:ir.model,name:stock_quant_history.model_stock_picking
+msgid "Transfer"
+msgstr "Transfert"
+
+#. module: stock_quant_history
 #: model:ir.model.fields,field_description:stock_quant_history.field_stock_quant_history__product_uom_id
 msgid "Unit of Measure"
 msgstr "Unité de mesure"
+
+#. module: stock_quant_history
+#: model:ir.model.fields,help:stock_quant_history.field_res_company__stock_history_snapshot_auto_locks_picking
+#: model:ir.model.fields,help:stock_quant_history.field_res_config_settings__stock_history_snapshot_auto_locks_picking
+#: model_terms:ir.ui.view,arch_db:stock_quant_history.res_config_settings_view_form
+msgid ""
+"When a stock quant history snapshot is generated, automatically locks all "
+"done pickings that are related to the snapshot."
+msgstr ""
+"Lorsqu'un historique des stocks est généré, toutes les préparations "
+"associées et terminées sont verrouillées."
+
+#. module: stock_quant_history
+#. odoo-python
+#: code:addons/stock_quant_history/models/stock_picking.py:0
+#, python-format
+msgid ""
+"You cannot unlock '%(name)s' because it has related stock quant history:\n"
+" - %(snapshot_text)s"
+msgstr ""
+"Déverrouillage impossible de la préparation '%(name)s' car un ou plusieurs historiques de stock existent :\n"
+" - %(snapshot_text)s"
 
 #. module: stock_quant_history
 #: model:ir.model,name:stock_quant_history.model_stock_quant_history_snapshot

--- a/stock_quant_history/i18n/it.po
+++ b/stock_quant_history/i18n/it.po
@@ -22,6 +22,13 @@ msgid "<span>History details</span>"
 msgstr "<span>Dettagli cronologia</span>"
 
 #. module: stock_quant_history
+#: model:ir.model.fields,field_description:stock_quant_history.field_res_company__stock_history_snapshot_auto_locks_picking
+#: model:ir.model.fields,field_description:stock_quant_history.field_res_config_settings__stock_history_snapshot_auto_locks_picking
+#: model_terms:ir.ui.view,arch_db:stock_quant_history.res_config_settings_view_form
+msgid "Auto lock picking on snapshot"
+msgstr ""
+
+#. module: stock_quant_history
 #: model:ir.model.fields,help:stock_quant_history.field_stock_quant_history_snapshot__previous_snapshot_id
 msgid "Base snapshot used to generate this snapshot"
 msgstr "Snapshot di base utilizzato per generare questo snapshot"
@@ -279,6 +286,24 @@ msgid "Unit of Measure"
 msgstr "Unità di misura"
 
 #. module: stock_quant_history
+#: model:ir.model.fields,help:stock_quant_history.field_res_company__stock_history_snapshot_auto_locks_picking
+#: model:ir.model.fields,help:stock_quant_history.field_res_config_settings__stock_history_snapshot_auto_locks_picking
+#: model_terms:ir.ui.view,arch_db:stock_quant_history.res_config_settings_view_form
+msgid ""
+"When a stock quant history snapshot is generated, automatically locks all "
+"done pickings that are related to the snapshot."
+msgstr ""
+
+#. module: stock_quant_history
+#. odoo-python
+#: code:addons/stock_quant_history/models/stock_picking.py:0
+#, python-format
+msgid ""
+"You cannot unlock '%(name)s' because it has related stock quant history:\n"
+" - %(snapshot_text)s"
+msgstr ""
+
+#. module: stock_quant_history
 #: model:ir.model,name:stock_quant_history.model_stock_quant_history_snapshot
 msgid "stock.quant.history generation configuration model"
-msgstr "modello configurazione stock.quant.history generation"
+msgstr ""

--- a/stock_quant_history/i18n/stock_quant_history.pot
+++ b/stock_quant_history/i18n/stock_quant_history.pot
@@ -19,6 +19,13 @@ msgid "<span>History details</span>"
 msgstr ""
 
 #. module: stock_quant_history
+#: model:ir.model.fields,field_description:stock_quant_history.field_res_company__stock_history_snapshot_auto_locks_picking
+#: model:ir.model.fields,field_description:stock_quant_history.field_res_config_settings__stock_history_snapshot_auto_locks_picking
+#: model_terms:ir.ui.view,arch_db:stock_quant_history.res_config_settings_view_form
+msgid "Auto lock picking on snapshot"
+msgstr ""
+
+#. module: stock_quant_history
 #: model:ir.model.fields,help:stock_quant_history.field_stock_quant_history_snapshot__previous_snapshot_id
 msgid "Base snapshot used to generate this snapshot"
 msgstr ""
@@ -262,6 +269,24 @@ msgstr ""
 #. module: stock_quant_history
 #: model:ir.model.fields,field_description:stock_quant_history.field_stock_quant_history__product_uom_id
 msgid "Unit of Measure"
+msgstr ""
+
+#. module: stock_quant_history
+#: model:ir.model.fields,help:stock_quant_history.field_res_company__stock_history_snapshot_auto_locks_picking
+#: model:ir.model.fields,help:stock_quant_history.field_res_config_settings__stock_history_snapshot_auto_locks_picking
+#: model_terms:ir.ui.view,arch_db:stock_quant_history.res_config_settings_view_form
+msgid ""
+"When a stock quant history snapshot is generated, automatically locks all "
+"done pickings that are related to the snapshot."
+msgstr ""
+
+#. module: stock_quant_history
+#. odoo-python
+#: code:addons/stock_quant_history/models/stock_picking.py:0
+#, python-format
+msgid ""
+"You cannot unlock '%(name)s' because it has related stock quant history:\n"
+" - %(snapshot_text)s"
 msgstr ""
 
 #. module: stock_quant_history

--- a/stock_quant_history/models/__init__.py
+++ b/stock_quant_history/models/__init__.py
@@ -1,2 +1,5 @@
-from . import stock_quant_history_snapshot
+from . import res_company
+from . import res_config_settings
+from . import stock_picking
 from . import stock_quant_history
+from . import stock_quant_history_snapshot

--- a/stock_quant_history/models/res_company.py
+++ b/stock_quant_history/models/res_company.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Foodles (http://www.foodles.co).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Company(models.Model):
+    _inherit = "res.company"
+    _check_company_auto = True
+
+    stock_history_snapshot_auto_locks_picking = fields.Boolean(
+        string="Auto lock picking on snapshot",
+        help="When a stock quant history snapshot is generated, "
+        "automatically locks all done pickings that are related to the snapshot.",
+        default=True,
+        groups="stock.group_stock_manager",
+    )

--- a/stock_quant_history/models/res_config_settings.py
+++ b/stock_quant_history/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Foodles (http://www.foodles.co).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    stock_history_snapshot_auto_locks_picking = fields.Boolean(
+        related="company_id.stock_history_snapshot_auto_locks_picking",
+        readonly=False,
+        groups="stock.group_stock_manager",
+    )

--- a/stock_quant_history/models/stock_picking.py
+++ b/stock_quant_history/models/stock_picking.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Foodles (https://www.foodles.co/).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, models
+from odoo.exceptions import ValidationError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def get_stock_quant_history(self):
+        """Get the last stock quant history related to this picking.
+        The picking must be done.
+        :return: stock.quant.history recordset"""
+        self.ensure_one()
+        history_model = self.env["stock.quant.history"]
+        if self.state == "done" and self.date_done:
+            domain = [
+                ("inventory_date", ">=", self.date_done),
+                ("product_id", "in", self.move_line_ids.mapped("product_id").ids),
+                "|",
+                ("lot_id", "in", self.move_line_ids.mapped("lot_id").ids),
+                ("lot_id", "=", False),
+            ]
+            return history_model.search(domain)
+        return history_model
+
+    def action_toggle_is_locked(self):
+        # Ensure the picking is allowed to be unlocked before toggling the lock status.
+        self.check_unlock_allowed()
+        return super().action_toggle_is_locked()
+
+    def check_unlock_allowed(self):
+        """Check if the picking can be unlocked.
+        :return: True if the picking can be unlocked
+        :raises ValidationError: if not allowed to unlock"""
+        self.ensure_one()
+        if self.is_locked:
+            history_lines = self.get_stock_quant_history()
+            if history_lines.exists():
+                snapshot_text = "\n - ".join(
+                    history_lines.mapped("snapshot_id").mapped("display_name")
+                )
+                raise ValidationError(
+                    _(
+                        "You cannot unlock '%(name)s' because it has related"
+                        " stock quant history:\n - %(snapshot_text)s"
+                    )
+                    % {
+                        "name": self.display_name,
+                        "snapshot_text": snapshot_text,
+                    }
+                )
+        return True
+
+    def write(self, vals):
+        # Constraint the lock status to avoid unlocking a record when a related quant
+        # history exists.
+        # An unlock action is propagated
+        if "is_locked" in vals and not vals.get("is_locked"):
+            # Reducing to locked status and done picking
+            for picking in self.filtered(
+                lambda pick: pick.is_locked and pick.state == "done" and pick.date_done
+            ):
+                picking.check_unlock_allowed()
+        return super().write(vals)

--- a/stock_quant_history/models/stock_quant_history_snapshot.py
+++ b/stock_quant_history/models/stock_quant_history_snapshot.py
@@ -161,37 +161,34 @@ class StockQuantHistorySnapshot(models.Model):
         _logger.info(
             "Apply %s stock.move.line since previous snapshot", len(stock_move_lines)
         )
+        pickings = self.env["stock.picking"]
         ignored_location_usage = self._ignored_location_usage()
         for move_line in stock_move_lines:
+            quantity = move_line.product_uom_id._compute_quantity(
+                move_line.quantity, move_line.product_id.uom_id
+            )
             if move_line.location_id.usage not in ignored_location_usage:
-                quant_history[
+                quant_copy = quant_history[
                     (move_line.product_id, move_line.lot_id, move_line.location_id)
-                ].quantity = tools.float_round(
-                    quant_history[
-                        (move_line.product_id, move_line.lot_id, move_line.location_id)
-                    ].quantity
-                    - move_line.product_uom_id._compute_quantity(
-                        move_line.quantity, move_line.product_id.uom_id
-                    ),
+                ]
+                quant_copy.quantity = tools.float_round(
+                    quant_copy.quantity - quantity,
                     precision_rounding=move_line.product_id.uom_id.rounding,
                 )
-
             if move_line.location_dest_id.usage not in ignored_location_usage:
-                quant_history[
+                quant_copy = quant_history[
                     (move_line.product_id, move_line.lot_id, move_line.location_dest_id)
-                ].quantity = tools.float_round(
-                    quant_history[
-                        (
-                            move_line.product_id,
-                            move_line.lot_id,
-                            move_line.location_dest_id,
-                        )
-                    ].quantity
-                    + move_line.product_uom_id._compute_quantity(
-                        move_line.quantity, move_line.product_id.uom_id
-                    ),
+                ]
+                quant_copy.quantity = tools.float_round(
+                    quant_copy.quantity + quantity,
                     precision_rounding=move_line.product_id.uom_id.rounding,
                 )
+            pickings |= move_line.picking_id
+
+        # Lock all related pickings
+        if self.env.company.stock_history_snapshot_auto_locks_picking:
+            _logger.info(f"Locking {len(pickings)} related pickings")
+            pickings.sudo().write({"is_locked": True})
         # remove line with zero to save same disk space
         # avoid loop with direct SQL query
         _logger.info("Remove useless stock_quant_history with quantity == 0")

--- a/stock_quant_history/readme/CONSTRIBUTORS.rst
+++ b/stock_quant_history/readme/CONSTRIBUTORS.rst
@@ -1,1 +1,3 @@
-* Pierre Verkest <pierreverkest84@gmail.com>
+* `Pierre Verkest <pierreverkest84@gmail.com>`_
+* `Foodles <https://www.foodles.com>`_
+    * `Stéphane Mangin <stephane.mangin@foodles.co>`_

--- a/stock_quant_history/readme/DESCRIPTION.md
+++ b/stock_quant_history/readme/DESCRIPTION.md
@@ -6,5 +6,7 @@ snapshot.
 To generate the first snapshot this module assume all stock.move.line
 are present in the database.
 
-Next snapshot is computed based on the previous snapshot present in the
-database.
+Next snapshot is computed based on the previous snapshot present in the database.
+
+Once a snapshot has been taken, every locked and done picking won't be able to unlock
+to avoid incoherent stock history.

--- a/stock_quant_history/readme/USAGE.md
+++ b/stock_quant_history/readme/USAGE.md
@@ -22,3 +22,8 @@ or
 
 - Go to: *Inventory / Reporting / History / Stock quants*
 - use different filters / group and views to make your analysis
+
+## Avoid pickings lock automation on snapshot creation
+
+- Go to: *Inventory / Configuration / Settings*
+- Uncheck the option *Auto lock picking on snapshot*

--- a/stock_quant_history/static/description/index.html
+++ b/stock_quant_history/static/description/index.html
@@ -377,6 +377,8 @@ snapshot.</p>
 are present in the database.</p>
 <p>Next snapshot is computed based on the previous snapshot present in the
 database.</p>
+<p>Once a snapshot has been taken, every locked and done picking won’t be
+able to unlock to avoid incoherent stock history.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -384,17 +386,18 @@ database.</p>
 <li><a class="reference internal" href="#generate-a-new-stock-snapshot" id="toc-entry-2">Generate a new stock snapshot</a></li>
 <li><a class="reference internal" href="#consult-stock-quant-for-a-given-snapshot" id="toc-entry-3">Consult stock quant for a given snapshot</a></li>
 <li><a class="reference internal" href="#compare-stock-over-snapshots" id="toc-entry-4">Compare stock over snapshots</a></li>
+<li><a class="reference internal" href="#avoid-pickings-lock-automation-on-snapshot-creation" id="toc-entry-5">Avoid pickings lock automation on snapshot creation</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-5">Known issues / Roadmap</a><ul>
-<li><a class="reference internal" href="#short-terms" id="toc-entry-6">Short terms</a></li>
-<li><a class="reference internal" href="#long-terms" id="toc-entry-7">Long terms</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-6">Known issues / Roadmap</a><ul>
+<li><a class="reference internal" href="#short-terms" id="toc-entry-7">Short terms</a></li>
+<li><a class="reference internal" href="#long-terms" id="toc-entry-8">Long terms</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-8">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-9">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-10">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-11">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-9">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-10">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-11">Authors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-12">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -432,18 +435,25 @@ snapshots</li>
 <li>use different filters / group and views to make your analysis</li>
 </ul>
 </div>
+<div class="section" id="avoid-pickings-lock-automation-on-snapshot-creation">
+<h2><a class="toc-backref" href="#toc-entry-5">Avoid pickings lock automation on snapshot creation</a></h2>
+<ul class="simple">
+<li>Go to: <em>Inventory / Configuration / Settings</em></li>
+<li>Uncheck the option <em>Auto lock picking on snapshot</em></li>
+</ul>
+</div>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-5">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-6">Known issues / Roadmap</a></h1>
 <div class="section" id="short-terms">
-<h2><a class="toc-backref" href="#toc-entry-6">Short terms</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Short terms</a></h2>
 <ul class="simple">
 <li>Add a companion module stock_quant_history_account to make the glue
 between stock_quant_history and stock_account adding the stock value</li>
 </ul>
 </div>
 <div class="section" id="long-terms">
-<h2><a class="toc-backref" href="#toc-entry-7">Long terms</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Long terms</a></h2>
 <ul class="simple">
 <li>Add filters (by locations, by product…) while generating tight
 snapshots (not reused as based snapshot)</li>
@@ -452,7 +462,7 @@ snapshots (not reused as based snapshot)</li>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-8">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-9">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/stock-logistics-reporting/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -460,15 +470,17 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-9">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-10">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-10">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-11">Authors</a></h2>
 <ul class="simple">
 <li>Pierre Verkest &lt;<a class="reference external" href="mailto:pierreverkest84&#64;gmail.com">pierreverkest84&#64;gmail.com</a>&gt;</li>
+<li>Foodles</li>
+<li>Stéphane Mangin &lt;<a class="reference external" href="mailto:stephane.mangin&#64;foodles.com">stephane.mangin&#64;foodles.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-12">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
@@ -476,8 +488,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/petrus-v"><img alt="petrus-v" src="https://github.com/petrus-v.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/petrus-v"><img alt="petrus-v" src="https://github.com/petrus-v.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/StephaneMangin"><img alt="StephaneMangin" src="https://github.com/StephaneMangin.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/stock-logistics-reporting/tree/17.0/stock_quant_history">OCA/stock-logistics-reporting</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/stock_quant_history/tests/__init__.py
+++ b/stock_quant_history/tests/__init__.py
@@ -1,1 +1,3 @@
+from . import common
 from . import test_stock_quant_history
+from . import test_stock_picking

--- a/stock_quant_history/tests/common.py
+++ b/stock_quant_history/tests/common.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Foodles (https://www.foodles.co/).
+# @author Pierre Verkest <pierreverkest84@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from collections import defaultdict
+
+from odoo import fields
+from odoo.tests import common
+
+
+class TestStockQuantHistoryCommon(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                queue_job__no_delay=True,  # no jobs thanks
+            )
+        )
+
+        cls.stock_history_now = cls.env["stock.quant.history.snapshot"].create(
+            {
+                "inventory_date": fields.Datetime.now(),
+            }
+        )
+
+        cls.stock_manager_user = cls.env["res.users"].create(
+            {
+                "name": "foo",
+                "login": "stock_manager",
+                "email": "foo@bar.com",
+                "lang": "en_US",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        (
+                            cls.env.ref("base.group_user")
+                            | cls.env.ref("stock.group_stock_manager")
+                        ).ids,
+                    )
+                ],
+            }
+        )
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.location = cls.warehouse.lot_stock_id
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "test",
+                "type": "product",
+                "tracking": "lot",
+            }
+        )
+        cls.lot = cls.env["stock.lot"].create(
+            {
+                "name": "lot test",
+                "product_id": cls.product.id,
+                "company_id": cls.warehouse.company_id.id,
+            }
+        )
+        cls.product_consu = cls.env["product.product"].create(
+            {
+                "name": "test",
+                "type": "consu",
+            }
+        )
+
+    def _update_product_stock(self, qty, uom=None):
+        lot = self.lot
+        location = self.location
+        if not uom:
+            uom = self.product.uom_id
+
+        qty_in_base_uom = uom._compute_quantity(qty, self.product.uom_id)
+
+        quant = self.env["stock.quant"].search(
+            [
+                ("product_id", "=", self.product.id),
+                ("location_id", "=", location.id),
+                ("lot_id", "=", lot.id if lot else False),
+            ],
+            limit=1,
+        )
+
+        if not quant:
+            quant = (
+                self.env["stock.quant"]
+                .with_context(inventory_mode=True)
+                .create(
+                    {
+                        "product_id": self.product.id,
+                        "location_id": location.id,
+                        "lot_id": lot.id if lot else False,
+                        "inventory_quantity": qty_in_base_uom,
+                    }
+                )
+            )
+            quant.action_apply_inventory()
+            return
+
+        quant.with_context(inventory_mode=True).write(
+            {
+                "inventory_quantity_auto_apply": qty_in_base_uom,
+            }
+        )
+
+    @classmethod
+    def quants_quantity_group_by(cls, recordset, key):
+        """inspired from sale_product_pack PR: gh:oca/product-pack/pull/159"""
+        groups = defaultdict(lambda: 0)
+        for elem in recordset:
+            groups[key(elem)] += elem.quantity
+        return groups
+
+    def assertQuantCompare(self, quants, expected_quants):
+        """works either with stock.quant or stock.quants.history"""
+
+        def group_key(quant):
+            return quant.product_id, quant.lot_id, quant.location_id
+
+        grouped_quants = self.quants_quantity_group_by(quants, group_key)
+        grouped_expected_quants = self.quants_quantity_group_by(
+            expected_quants, group_key
+        )
+        errors1 = []
+        errors2 = []
+        ok = []
+        for key, quantity in grouped_quants.items():
+            if grouped_expected_quants[key] != quantity:
+                errors1.append(
+                    f"got {quantity} != Expected {grouped_expected_quants[key]} for"
+                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
+                )
+            else:
+                ok.append(
+                    f"{grouped_expected_quants[key]} for "
+                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
+                    f"is the same {quantity} !"
+                )
+
+        for key, quantity in grouped_expected_quants.items():
+            if grouped_quants[key] != quantity:
+                errors2.append(
+                    f"got {grouped_quants[key]} != Expected {quantity} for "
+                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
+                )
+        self.assertEqual(
+            len(errors1) + len(errors2),
+            0,
+            "Following diff detected:\n\n".join(errors1)
+            + "\n or/and \n "
+            + "\n".join(errors2)
+            + "\n\nOK records:\n"
+            + "\n".join(ok),
+        )

--- a/stock_quant_history/tests/test_stock_picking.py
+++ b/stock_quant_history/tests/test_stock_picking.py
@@ -1,0 +1,190 @@
+# Copyright 2025 Foodles (https://www.foodles.co/).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from freezegun import freeze_time
+
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged, users
+
+from . import common
+
+
+@tagged("post_install", "-at_install")
+@freeze_time("2022-06-01 12:00+00")
+class TestStockPickingLock(common.TestStockQuantHistoryCommon):
+    """Test the lock constraint functionality on picking.
+          ┌────────────────────────┐
+          │(unlock, no history) TC3│
+          ▼                        │
+    ┌───────────┐            ┌─────┴─────┐
+    │ Unlocked  ├───────────►│  Locked   │
+    └───────────┘ (lock) TC1 └─────┬─────┘
+                                   │
+    (unlock, history exists) TC2   ▼
+                             ┌───────────┐
+                             │ Exception │
+                             └───────────┘
+    """
+
+    def setUp(self):
+        super().setUp()
+        customer_location = self.env.ref("stock.stock_location_customers")
+        # prepare a snapshot
+        self.picking = self.env["stock.picking"].create(
+            {
+                "name": "Test Picking",
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "location_id": self.location.id,
+                "location_dest_id": customer_location.id,
+                "is_locked": False,
+            }
+        )
+        self.move_line = self.env["stock.move.line"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.location.id,
+                "location_dest_id": customer_location.id,
+                "picking_id": self.picking.id,
+                "product_uom_id": self.product.uom_id.id,
+                "lot_id": self.lot.id,
+                "quantity": 1,
+            }
+        )
+        # Force the automatic picking lock setting
+        self.env.company.sudo().stock_history_snapshot_auto_locks_picking = True
+
+    @users("stock_manager")
+    def test1_lock_unlock_without_history(self):
+        """Test the lock functionality."""
+        # Assign and confirm the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.button_validate()
+        # This picking should be unlocked (no changes on standard behavior)
+        self.picking.write({"is_locked": True})
+        self.assertTrue(self.picking.is_locked, "The picking should be locked.")
+        self.picking.write({"is_locked": False})
+        self.assertFalse(
+            self.picking.is_locked, "The picking should be unlocked after toggling."
+        )
+
+    @users("stock_manager")
+    def test2_unlock_with_history(self):
+        """Test the unlock functionality with history."""
+        # Validate and finish the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.button_validate()
+        # Create a snapshot including this picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        # Try to unlock the picking
+        with self.assertRaises(ValidationError):
+            self.picking.write({"is_locked": False})
+
+    @users("stock_manager")
+    def test3_unlock_with_past_history(self):
+        """Test the unlock functionality without history."""
+        # Create a snapshot before confirming the picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        # Validate and finish the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.button_validate()
+        self.picking.write({"is_locked": True})
+        self.assertTrue(self.picking.is_locked, "The picking should be locked.")
+        # This picking should be unlocked (no changes on standard behavior)
+        self.picking.write({"is_locked": False})
+        self.assertFalse(
+            self.picking.is_locked, "The picking should be unlocked after toggling."
+        )
+
+    @users("stock_manager")
+    def test_lock_done_picking_on_snapshot_creation_with_option(self):
+        """Test that the picking is locked when a snapshot is created."""
+        # Validate and finish the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.button_validate()
+        # Create a snapshot including this picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        # The picking should be locked after the snapshot creation
+        self.assertTrue(
+            self.picking.is_locked, "The picking should be locked after snapshot."
+        )
+
+    @users("stock_manager")
+    def test_lock_done_picking_on_snapshot_creation_no_option(self):
+        """Test that the picking is not locked when a snapshot is created without the
+        option set (default behavior)."""
+        self.env.company.sudo().stock_history_snapshot_auto_locks_picking = False
+        # Validate and finish the picking to be locked
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.button_validate()
+        self.stock_history_now.action_generate_stock_quant_history()
+        # The picking should remain unlocked after the snapshot creation
+        self.assertFalse(
+            self.picking.is_locked, "The picking should remain unlocked after snapshot."
+        )
+
+    @users("stock_manager")
+    def test_unlocked_pending_picking_on_snapshot_creation(self):
+        """Test that the picking remains unlocked when a snapshot is created."""
+        # Create a snapshot including this picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        # The picking should remain unlocked after the snapshot creation
+        self.assertFalse(
+            self.picking.is_locked, "The picking should remain unlocked after snapshot."
+        )
+
+    @users("stock_manager")
+    def test_method_get_stock_quant_history_done_picking(self):
+        """Test the method to get stock quant history related to a picking."""
+        # Create a snapshot including this picking
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.button_validate()
+        self.stock_history_now.action_generate_stock_quant_history()
+        history = self.picking.get_stock_quant_history()
+        self.assertTrue(
+            history.exists(),
+            "The picking should have related stock quant history.",
+        )
+
+    @users("stock_manager")
+    def test_method_get_stock_quant_history_not_done_picking(self):
+        """Test the method to get stock quant history related to a pending picking."""
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        history = self.picking.get_stock_quant_history()
+        self.assertFalse(
+            history.exists(),
+            "The pending picking should not have related stock quant history.",
+        )
+
+    @users("stock_manager")
+    def test_method_action_toggle_is_locked(self):
+        """Test the action to toggle the lock status of a picking."""
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        # No exception should be raised when toggling the lock status
+        self.picking.action_toggle_is_locked()
+        # Then validate and finish the picking to be locked
+        self.picking.button_validate()
+        self.stock_history_now.action_generate_stock_quant_history()
+        with self.assertRaises(ValidationError):
+            self.picking.action_toggle_is_locked()
+
+    def test_method_check_unlock_allowed(self):
+        """Test the method to check if a picking can be unlocked."""
+        self.picking.action_assign()
+        self.picking.action_confirm()
+        self.picking.button_validate()
+        # Unlock the picking
+        self.picking.write({"is_locked": False})
+        self.picking.check_unlock_allowed()
+        # Create a snapshot including this picking
+        self.stock_history_now.action_generate_stock_quant_history()
+        with self.assertRaises(ValidationError):
+            self.picking.check_unlock_allowed()

--- a/stock_quant_history/tests/test_stock_quant_history.py
+++ b/stock_quant_history/tests/test_stock_quant_history.py
@@ -1,159 +1,17 @@
-from collections import defaultdict
+# Copyright 2025 Foodles (https://www.foodles.co/).
+# @author Pierre Verkest <pierreverkest84@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import AccessError
-from odoo.tests import TransactionCase, users
+from odoo.tests import users
+
+from . import common
 
 
-class TestStockQuantHistory(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(
-            context=dict(
-                cls.env.context,
-                test_queue_job_no_delay=True,  # no jobs thanks
-            )
-        )
-
-        cls.stock_history_now = cls.env["stock.quant.history.snapshot"].create(
-            {
-                "inventory_date": fields.Datetime.now(),
-            }
-        )
-
-        cls.stock_manager_user = cls.env["res.users"].create(
-            {
-                "name": "foo",
-                "login": "stock_manager",
-                "email": "foo@bar.com",
-                "lang": "en_US",
-                "groups_id": [
-                    (
-                        6,
-                        0,
-                        (
-                            cls.env.ref("base.group_user")
-                            | cls.env.ref("stock.group_stock_manager")
-                        ).ids,
-                    )
-                ],
-            }
-        )
-        cls.warehouse = cls.env.ref("stock.warehouse0")
-        cls.location = cls.warehouse.lot_stock_id
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "test",
-                "type": "product",
-                "tracking": "lot",
-            }
-        )
-        cls.lot = cls.env["stock.lot"].create(
-            {
-                "name": "lot test",
-                "product_id": cls.product.id,
-                "company_id": cls.warehouse.company_id.id,
-            }
-        )
-        cls.product_consu = cls.env["product.product"].create(
-            {
-                "name": "test",
-                "type": "consu",
-            }
-        )
-
-    def _update_product_stock(self, qty, uom=None):
-        lot = self.lot
-        location = self.location
-        if not uom:
-            uom = self.product.uom_id
-
-        qty_in_base_uom = uom._compute_quantity(qty, self.product.uom_id)
-
-        quant = self.env["stock.quant"].search(
-            [
-                ("product_id", "=", self.product.id),
-                ("location_id", "=", location.id),
-                ("lot_id", "=", lot.id if lot else False),
-            ],
-            limit=1,
-        )
-
-        if not quant:
-            quant = (
-                self.env["stock.quant"]
-                .with_context(inventory_mode=True)
-                .create(
-                    {
-                        "product_id": self.product.id,
-                        "location_id": location.id,
-                        "lot_id": lot.id if lot else False,
-                        "inventory_quantity": qty_in_base_uom,
-                    }
-                )
-            )
-            quant.action_apply_inventory()
-            return
-
-        quant.with_context(inventory_mode=True).write(
-            {
-                "inventory_quantity_auto_apply": qty_in_base_uom,
-            }
-        )
-
-    @classmethod
-    def quants_quantity_group_by(cls, recordset, key):
-        """inspired from sale_product_pack PR: gh:oca/product-pack/pull/159"""
-        groups = defaultdict(lambda: 0)
-        for elem in recordset:
-            groups[key(elem)] += elem.quantity
-        return groups
-
-    def assertQuantCompare(self, quants, expected_quants):
-        """works either with stock.quant or stock.quants.history"""
-
-        def group_key(quant):
-            return quant.product_id, quant.lot_id, quant.location_id
-
-        grouped_quants = self.quants_quantity_group_by(quants, group_key)
-        grouped_expected_quants = self.quants_quantity_group_by(
-            expected_quants, group_key
-        )
-        errors1 = []
-        errors2 = []
-        ok = []
-        for key, quantity in grouped_quants.items():
-            if grouped_expected_quants[key] != quantity:
-                errors1.append(
-                    f"got {quantity} != Expected {grouped_expected_quants[key]} for"
-                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
-                )
-            else:
-                ok.append(
-                    f"{grouped_expected_quants[key]} for "
-                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
-                    f"is the same {quantity} !"
-                )
-
-        for key, quantity in grouped_expected_quants.items():
-            if grouped_quants[key] != quantity:
-                errors2.append(
-                    f"got {grouped_quants[key]} != Expected {quantity} for "
-                    f"{key}: [{key[0].name}, {key[1].name}, {key[2].name}], "
-                )
-        self.assertEqual(
-            len(errors1) + len(errors2),
-            0,
-            "Following diff detected:\n\n".join(errors1)
-            + "\n or/and \n "
-            + "\n".join(errors2)
-            + "\n\nOK records:\n"
-            + "\n".join(ok),
-        )
-
+class TestStockQuantHistory(common.TestStockQuantHistoryCommon):
     def test_compare_quant(self):
         self.stock_history_now.action_generate_stock_quant_history()
         self.assertQuantCompare(

--- a/stock_quant_history/views/res_config_settings_views.xml
+++ b/stock_quant_history/views/res_config_settings_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Foodles (http://www.foodles.co).
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">
+            Stock settings: auto lock picking on snapshot creation
+        </field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <setting id="warning_info" position="after">
+                <setting
+                    id="stock_history_snapshot"
+                    company_dependent="1"
+                    string="Auto lock picking on snapshot"
+                    help="When a stock quant history snapshot is generated, automatically locks all done pickings that are related to the snapshot."
+                >
+                    <field name="stock_history_snapshot_auto_locks_picking" />
+                </setting>
+            </setting>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add a constraint on locked picking while an history snapshot is generated.

Included a light refactoring of tests suites.

Propagated from [14.0 PR](https://github.com/OCA/stock-logistics-reporting/pull/414)