### PR TITLE
[14.0][FIX] stock_picking_report_valued: prevent singleton error in `res.currency`

### DIFF
--- a/stock_picking_report_valued/report/stock_picking_report_valued.xml
+++ b/stock_picking_report_valued/report/stock_picking_report_valued.xml
@@ -94,12 +94,15 @@
                 <td class="text-right" groups="product.group_discount_per_so_line">
                     <span t-field="move_line.sale_discount" />
                 </td>
-                <td class="text-right"><span
+                <td class="text-right">
+                    <span
                         t-field="move_line.sale_price_subtotal"
-                    /></td>
-                <td class="text-right"><span
-                        t-field="move_line.sale_tax_description"
-                    /></td>
+                        t-options='{"display_currency": o.currency_id}'
+                    />
+                </td>
+                <td class="text-right">
+                    <span t-field="move_line.sale_tax_description" />
+                </td>
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
for warehouses with multiple delivery steps

This report adds new fields of `Monetary` type. When the report is printed, Odoo tries to access `currency_id`, which is related to the `sale_line`. This field is only set on the final delivery step.

However, when the warehouse is configured with two or three delivery steps, the initial pickings contain move lines that are not linked to any sale line, which raises the following error: `ValueError: Expected singleton: res.currency()`

This commit ensures that the fields are rendered only if at least one move line is linked to a sale line, thus preventing the error.

TT50920
@Tecnativa @pedrobaeza @carlosdauden @CarlosRoca13 could you please review this?