### PR TITLE
[16.0][IMP] stock_quantity_history_location: invisible location except from stock.quant view

### DIFF
--- a/stock_quantity_history_location/README.rst
+++ b/stock_quantity_history_location/README.rst
@@ -28,23 +28,30 @@ Stock Quantity History Location
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module allows to run an Inventory report or Inventory Valuation
-report by location, for a past date or for current date.
+This module allows to run an Inventory report by location, for a past date or for current date.
 
 **Table of contents**
 
 .. contents::
    :local:
 
+Use Cases / Context
+===================
+
+In the standard behavior, when a user generates an inventory report for a specific date, 
+the report shows data for all locations without the ability to filter or group by 
+location.
+
+This module adds the ability to view inventory quantities for a specific location on a 
+specific date.
+
 Usage
 =====
 
-* Go to:  *Inventory / Reporting / Inventory or Inventory Valuation*
-* Filter by location
-* **Optionally: Mark if you want to include child location**
-* Choose a moment in time:
-    * Current Inventory
-    * At a Specific Date
+1. Go to **Inventory / Reporting / Locations**
+2. Click **INVENTORY AT DATE & LOCATION**
+3. Select the desired **Location** and specify the **Inventory at Date**
+4. Click the **CONFIRM** button
 
 Bug Tracker
 ===========
@@ -71,6 +78,9 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Ernesto Tejeda
+* `Quartile <https://www.quartile.co>`_:
+
+  * Aung Ko Ko Lin
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_quantity_history_location/readme/CONTEXT.rst
+++ b/stock_quantity_history_location/readme/CONTEXT.rst
@@ -1,0 +1,6 @@
+In the standard behavior, when a user generates an inventory report for a specific date, 
+the report shows data for all locations without the ability to filter or group by 
+location.
+
+This module adds the ability to view inventory quantities for a specific location on a 
+specific date.

--- a/stock_quantity_history_location/readme/CONTRIBUTORS.rst
+++ b/stock_quantity_history_location/readme/CONTRIBUTORS.rst
@@ -2,3 +2,6 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Ernesto Tejeda
+* `Quartile <https://www.quartile.co>`_:
+
+  * Aung Ko Ko Lin

--- a/stock_quantity_history_location/readme/DESCRIPTION.rst
+++ b/stock_quantity_history_location/readme/DESCRIPTION.rst
@@ -1,2 +1,1 @@
-This module allows to run an Inventory report or Inventory Valuation
-report by location, for a past date or for current date.
+This module allows to run an Inventory report by location, for a past date or for current date.

--- a/stock_quantity_history_location/readme/USAGE.rst
+++ b/stock_quantity_history_location/readme/USAGE.rst
@@ -1,6 +1,4 @@
-* Go to:  *Inventory / Reporting / Inventory or Inventory Valuation*
-* Filter by location
-* **Optionally: Mark if you want to include child location**
-* Choose a moment in time:
-    * Current Inventory
-    * At a Specific Date
+1. Go to **Inventory / Reporting / Locations**
+2. Click **INVENTORY AT DATE & LOCATION**
+3. Select the desired **Location** and specify the **Inventory at Date**
+4. Click the **CONFIRM** button

--- a/stock_quantity_history_location/static/description/index.html
+++ b/stock_quantity_history_location/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -370,40 +369,40 @@ ul.auto-toc {
 !! source digest: sha256:ac43dd7053855a1321ed1443b61c325d68163a28e58509877bc63879cf59c05e
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/stock-logistics-reporting/tree/16.0/stock_quantity_history_location"><img alt="OCA/stock-logistics-reporting" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--reporting-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/stock-logistics-reporting-16-0/stock-logistics-reporting-16-0-stock_quantity_history_location"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/stock-logistics-reporting&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module allows to run an Inventory report or Inventory Valuation
-report by location, for a past date or for current date.</p>
+<p>This module allows to run an Inventory report by location, for a past date or for current date.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#use-cases-context" id="toc-entry-1">Use Cases / Context</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
+</div>
+<div class="section" id="use-cases-context">
+<h1><a class="toc-backref" href="#toc-entry-1">Use Cases / Context</a></h1>
+<p>In the standard behavior, when a user generates an inventory report for a specific date,
+the report shows data for all locations without the ability to filter or group by
+location.</p>
+<p>This module adds the ability to view inventory quantities for a specific location on a
+specific date.</p>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
-<ul class="simple">
-<li>Go to:  <em>Inventory / Reporting / Inventory or Inventory Valuation</em></li>
-<li>Filter by location</li>
-<li><strong>Optionally: Mark if you want to include child location</strong></li>
-<li><dl class="first docutils">
-<dt>Choose a moment in time:</dt>
-<dd><ul class="first last">
-<li>Current Inventory</li>
-<li>At a Specific Date</li>
-</ul>
-</dd>
-</dl>
-</li>
-</ul>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
+<ol class="arabic simple">
+<li>Go to <strong>Inventory / Reporting / Locations</strong></li>
+<li>Click <strong>INVENTORY AT DATE &amp; LOCATION</strong></li>
+<li>Select the desired <strong>Location</strong> and specify the <strong>Inventory at Date</strong></li>
+<li>Click the <strong>CONFIRM</strong> button</li>
+</ol>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/stock-logistics-reporting/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -411,25 +410,29 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Jordi Ballester Alomar &lt;<a class="reference external" href="mailto:jordi.ballester&#64;forgeflow.com">jordi.ballester&#64;forgeflow.com</a>&gt;</li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Ernesto Tejeda</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/stock_quantity_history_location/tests/test_stock_quantity_history_location.py
+++ b/stock_quantity_history_location/tests/test_stock_quantity_history_location.py
@@ -31,35 +31,41 @@ class TestStockQuantityHistoryLocation(TestCommon):
         )
         cls._create_stock_move(cls, location_dest_id=cls.child_test_stock_loc, qty=100)
 
-    def test_01_wizard_past_date(self):
+    def get_stock_quantity_history_action(self, location, to_date):
         wizard = self.env["stock.quantity.history"].create(
             {
-                "location_id": self.test_stock_loc.id,
-                "include_child_locations": True,
-                "inventory_datetime": fields.Datetime.now(),
+                "location_id": location.id,
+                "inventory_datetime": to_date,
             }
         )
-        action = wizard.with_context(company_owned=True).open_at_date()
+        return wizard.open_at_date()
+
+    def test_stock_quantity_history_location(self):
+        current_date = fields.Datetime.now()
+        past_date = fields.Datetime.to_datetime("2019-08-10 00:00:00")
+        action = self.get_stock_quantity_history_action(
+            self.child_test_stock_loc, current_date
+        )
+        self.assertEqual(action["context"].get("to_date"), current_date)
         self.assertEqual(
             self.product.with_context(**action["context"]).qty_available, 100.0
         )
+        action = self.get_stock_quantity_history_action(
+            self.child_test_stock_loc, past_date
+        )
+        to_date_in_context = action["context"].get("to_date")
+        self.assertIsNotNone(to_date_in_context)
+        self.assertEqual(to_date_in_context, past_date)
         self.assertEqual(
-            self.product.with_context(
-                location=self.child_test_stock_loc.id, to_date="2019-08-10"
-            ).qty_available,
-            0.0,
+            self.product.with_context(**action["context"]).qty_available, 0.0
         )
-
-    def test_02_wizard_current(self):
-        wizard = self.env["stock.quantity.history"].create(
-            {"location_id": self.test_stock_loc.id, "include_child_locations": False}
+        action = self.get_stock_quantity_history_action(
+            self.test_stock_loc, current_date
         )
-        action = wizard.with_context().open_at_date()
-        self.assertEqual(action["context"]["compute_child"], False)
-        self.assertEqual(action["context"]["location"], self.test_stock_loc.id)
-        wizard = self.env["stock.quantity.history"].create(
-            {"location_id": self.test_stock_loc.id, "include_child_locations": True}
+        self.assertEqual(
+            self.product.with_context(**action["context"]).qty_available, 100.0
         )
-        action = wizard.with_context().open_at_date()
-        self.assertEqual(action["context"]["compute_child"], True)
-        self.assertEqual(action["context"]["location"], self.test_stock_loc.id)
+        action = self.get_stock_quantity_history_action(self.test_stock_loc, past_date)
+        self.assertEqual(
+            self.product.with_context(**action["context"]).qty_available, 0.0
+        )

--- a/stock_quantity_history_location/wizards/stock_quantity_history.py
+++ b/stock_quantity_history_location/wizards/stock_quantity_history.py
@@ -13,7 +13,6 @@ class StockQuantityHistory(models.TransientModel):
     location_id = fields.Many2one(
         "stock.location", domain=[("usage", "in", ["internal", "transit"])]
     )
-    include_child_locations = fields.Boolean(default=True)
 
     def open_at_date(self):
         action = super().open_at_date()
@@ -21,9 +20,6 @@ class StockQuantityHistory(models.TransientModel):
         ctx = safe_eval(ctx) if isinstance(ctx, str) else ctx
         if self.location_id:
             ctx["location"] = self.location_id.id
-            ctx["compute_child"] = self.include_child_locations
-            if ctx.get("company_owned", False):
-                ctx.pop("company_owned")
             action[
                 "display_name"
             ] = f"{self.location_id.complete_name} - {action['display_name']}"

--- a/stock_quantity_history_location/wizards/stock_quantity_history.xml
+++ b/stock_quantity_history_location/wizards/stock_quantity_history.xml
@@ -7,7 +7,11 @@
         <field name="inherit_id" ref="stock.view_stock_quantity_history" />
         <field name="arch" type="xml">
             <field name="inventory_datetime" position="before">
-                <field name="location_id" groups="stock.group_stock_multi_locations" />
+                <field
+                    name="location_id"
+                    groups="stock.group_stock_multi_locations"
+                    invisible="context.get('active_model') != 'stock.quant'"
+                />
                 <field
                     name="include_child_locations"
                     attrs="{'invisible': [('location_id', '=', False)]}"

--- a/stock_quantity_history_location/wizards/stock_quantity_history.xml
+++ b/stock_quantity_history_location/wizards/stock_quantity_history.xml
@@ -12,11 +12,6 @@
                     groups="stock.group_stock_multi_locations"
                     invisible="context.get('active_model') != 'stock.quant'"
                 />
-                <field
-                    name="include_child_locations"
-                    attrs="{'invisible': [('location_id', '=', False)]}"
-                    groups="stock.group_stock_multi_locations"
-                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This PR makes the location field invisible when the model is not stock.quant (locations view), because the location context is not used in other models (e.g., `stock.valuation.layer`) and choosing location will not effect the functionality. So, displaying this field in the pop-up of other models (e.g., Stock Valuation Layer) may confuse users.

@qrtl QT4756