### PR TITLE
[18.0] [FIX] printing_auto_stock_picking: ir rule

### DIFF
--- a/printing_auto_stock_picking/security/ir_rule.xml
+++ b/printing_auto_stock_picking/security/ir_rule.xml
@@ -3,7 +3,7 @@
     <record id="ir_rule_user" model="ir.rule">
         <field name="name">stock picking auto print</field>
         <field name="model_id" ref="printing_auto_base.model_printing_auto" />
-        <field name="domain_force">[("model", "=", "stock.picking.type")]</field>
+        <field name="domain_force">[("model", "=", "stock.picking")]</field>
         <field name="groups" eval="[(4, ref('stock.group_stock_user'))]" />
         <field name="perm_create" eval="0" />
         <field name="perm_write" eval="0" />


### PR DESCRIPTION
a5ce681d added the ir.rule and domains. However, the model used was wrong. Instead of targeting printing.auto with `stock.picking` as model, it targeted `stock.picking.type`.

That was partially fixed by a5ce681d, but this `ir.rule` was missing.

@jbaudoux 