### PR TITLE
[16.0][FIX] stock_picking_report_valued: Fix currency_id field

### DIFF
--- a/stock_picking_report_valued/models/stock_picking.py
+++ b/stock_picking_report_valued/models/stock_picking.py
@@ -4,7 +4,7 @@
 # Copyright 2016 Tecnativa - Luis M. Ontalba
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockPicking(models.Model):
@@ -12,10 +12,10 @@ class StockPicking(models.Model):
 
     valued = fields.Boolean(related="partner_id.valued_picking", readonly=True)
     currency_id = fields.Many2one(
-        related="sale_id.currency_id",
-        readonly=True,
+        comodel_name="res.currency",
         string="Currency",
-        related_sudo=True,  # See explanation for sudo in compute method
+        compute="_compute_currency_id",
+        compute_sudo=True,  # for avoiding access problems
     )
     amount_untaxed = fields.Monetary(
         compute="_compute_amount_all",
@@ -46,3 +46,8 @@ class StockPicking(models.Model):
                     "amount_total": amount_untaxed + amount_tax,
                 }
             )
+
+    @api.depends("sale_id", "sale_id.currency_id", "company_id")
+    def _compute_currency_id(self):
+        for item in self:
+            item.currency_id = item.sale_id.currency_id or item.company_id.currency_id


### PR DESCRIPTION
We make sure that the currency_id field always has a value to avoid errors. For example, when installing this module with stock_picking_report_delivery_cost and running the tests, there is a case where the picking has no currency defined, which blocks the CI.

cc @Tecnativa

ping @victoralmau @pedrobaeza 