### PR TITLE
[18.0][FIX] printing_auto_stock_picking: domain

### DIFF
--- a/printing_auto_stock_picking/models/stock_picking_type.py
+++ b/printing_auto_stock_picking/models/stock_picking_type.py
@@ -11,5 +11,4 @@ class StockPickingType(models.Model):
     auto_printing_ids = fields.Many2many(
         "printing.auto",
         string="Auto Printing Configuration",
-        domain=[("model", "=", "stock.picking")],
     )

--- a/printing_auto_stock_picking/views/stock_picking_type.xml
+++ b/printing_auto_stock_picking/views/stock_picking_type.xml
@@ -8,6 +8,7 @@
                 <separator string="Auto Printing Configuration" colspan="4" />
                 <field
                     name="auto_printing_ids"
+                    domain="[('model', '=', 'stock.picking')]"
                     context="{'default_model': 'stock.picking'}"
                 />
             </page>


### PR DESCRIPTION
Allow other models to be configured on a picking type

cc @sebalix 