### PR TITLE
[18.0][FIX] stock_picking_report_valued: wrong prices

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -60,7 +60,6 @@ class StockMoveLine(models.Model):
             if not valued_line:
                 continue
             quantity = line._get_report_valued_quantity()
-            sale_line_uom = valued_line.product_uom
             different_uom = valued_line.product_uom != line.product_uom_id
             # If order line quantity don't match with move line quantity compute values
             different_qty = float_compare(
@@ -73,15 +72,9 @@ class StockMoveLine(models.Model):
                 line.sale_line.mapped("tax_id")
                 # Create virtual sale line with stock move line quantity
                 sol_vals = line.sale_line._convert_to_write(line.sale_line._cache)
+                sol_vals["product_uom_qty"] = quantity
+                sol_vals.pop("price_subtotal", None)
                 valued_line = line.sale_line.new(sol_vals)
-                valued_line.product_uom_qty = quantity
-            if different_qty:
-                # Force original price unit to avoid pricelist recomputed (not needed)
-                valued_line.price_unit = line.sale_line.price_unit
-            if different_uom:
-                valued_line.price_unit = sale_line_uom._compute_price(
-                    valued_line.price_unit, line.product_uom_id
-                )
             line.update(
                 {
                     "sale_tax_description": ", ".join(
@@ -90,6 +83,6 @@ class StockMoveLine(models.Model):
                     "sale_price_subtotal": valued_line.price_subtotal,
                     "sale_price_tax": valued_line.price_tax,
                     "sale_price_total": valued_line.price_total,
-                    "sale_price_unit": valued_line.price_unit,
+                    "sale_price_unit": line.sale_line.price_unit,
                 }
             )


### PR DESCRIPTION
- The way the fields were calculated has been modified, since after performing the new() function, it recalculates the fields and loses them, only showing the unit price at the end. Therefore, it has been modified so that if it has a quantity different from the sales order or a different UOM, it first calculates the subtotal price and then performs the new() function. This way, the prices are calculated correctly in the report and the lines.

- I'm leaving screenshots taken on the runboat so you can replicate it.

<img width="1527" height="690" alt="image" src="https://github.com/user-attachments/assets/02405476-f63a-4e14-9c83-0ab5b84e79ce" />

<img width="1528" height="550" alt="image" src="https://github.com/user-attachments/assets/f53093cf-d525-4ac3-851e-f1bc5ac6e65b" />

<img width="777" height="564" alt="image" src="https://github.com/user-attachments/assets/b3be56e9-ea25-4397-810a-7b1a9d42a857" />
