### PR TITLE
[18.0][FIX] stock_picking_report_valued: remove deprecated field from stock_move_line

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -43,7 +43,7 @@ class StockMoveLine(models.Model):
     )
 
     def _get_report_valued_quantity(self):
-        return self.quantity or self.reserved_qty
+        return self.quantity
 
     def _compute_sale_order_line_fields(self):
         """This is computed with sudo for avoiding problems if you don't have


### PR DESCRIPTION
The field `reserved_qty` has been removed from `stock.move.line` in Odoo 18.0. The method `_get_report_valued_quantity` still references it as a fallback, causing an `AttributeError` when rendering reports.

<img width="1062" height="528" alt="image" src="https://github.com/user-attachments/assets/3a917341-2cc3-4a49-86b2-9ba723d8f198" />
