### PR TITLE
[16.0][FIX] stock_picking_report_valued: handle missing currency on manual move lines

### DIFF
--- a/stock_picking_report_valued/report/stock_picking_report_valued.xml
+++ b/stock_picking_report_valued/report/stock_picking_report_valued.xml
@@ -7,8 +7,10 @@
         </xpath>
         <xpath expr="//th[@name='th_sml_quantity']" position="after">
             <t t-if="o.valued and o.sale_id and o.move_line_ids and is_outgoing">
-                <th name="th_sml_unit_price" class="text-end"><strong
-                    >Unit Price</strong></th>
+                <th name="th_sml_unit_price" class="text-end">
+                    <strong>Unit Price
+                    </strong>
+                </th>
                 <th
                     name="th_sml_discount"
                     class="text-end"
@@ -16,9 +18,13 @@
                 >
                     <strong>Discount</strong>
                 </th>
-                <th name="th_sml_subtotal" class="text-end"><strong
-                    >Subtotal</strong></th>
-                <th name="th_sml_taxes" class="text-end"><strong>Taxes</strong></th>
+                <th name="th_sml_subtotal" class="text-end">
+                    <strong>Subtotal
+                    </strong>
+                </th>
+                <th name="th_sml_taxes" class="text-end">
+                    <strong>Taxes</strong>
+                </th>
             </t>
         </xpath>
         <xpath expr="//th[@name='th_sml_qty_ordered']" position="attributes">
@@ -66,9 +72,15 @@
                 <table class="table table-sm mt32">
                     <thead>
                         <tr>
-                            <th class="text-end"><strong>Untaxed Amount</strong></th>
-                            <th class="text-end"><strong>Taxes</strong></th>
-                            <th class="text-end"><strong>Total</strong></th>
+                            <th class="text-end">
+                                <strong>Untaxed Amount</strong>
+                            </th>
+                            <th class="text-end">
+                                <strong>Taxes</strong>
+                            </th>
+                            <th class="text-end">
+                                <strong>Total</strong>
+                            </th>
                         </tr>
                     </thead>
                     <tbody>
@@ -130,7 +142,8 @@
         <xpath expr="//td[@name='move_line_lot_qty_done']" position="after">
             <t t-if="o.valued and o.sale_id and o.move_line_ids and is_outgoing">
                 <td name="td_sml_unit_price" class="text-end">
-                    <span t-field="move_line.sale_price_unit" /></td>
+                    <span t-field="move_line.sale_price_unit" />
+                </td>
                 <td
                     name="td_sml_discount"
                     class="text-end"
@@ -139,9 +152,20 @@
                     <span t-field="move_line.sale_discount" />
                 </td>
                 <td name="td_sml_subtotal" class="text-end">
-                    <span t-field="move_line.sale_price_subtotal" /></td>
+                    <span
+                        t-field="move_line.sale_price_subtotal"
+                        t-options="{
+                                'widget': 'monetary',
+                                'display_currency': (
+                                    move_line.currency_id
+                                    or move_line.move_id.sale_line_id.currency_id
+                                    or move_line.company_id.currency_id
+                                ) }"
+                    />
+                </td>
                 <td name="td_sml_taxes" class="text-end">
-                    <span t-field="move_line.sale_tax_description" /></td>
+                    <span t-field="move_line.sale_tax_description" />
+                </td>
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
@BinhexTeam

Problem

When using the module stock_picking_report_valued, printing the valued picking report may fail with:
ValueError: Expected singleton: res.currency()

This happens when a user manually adds stock move lines to a picking that is already done.
These move lines are not linked to a sale order line and therefore do not have a currency set.

Since the report displays sale_price_subtotal as a Monetary field, the QWeb renderer expects a valid currency and crashes when none is found.

This scenario is fully allowed by Odoo and represents a valid user workflow.

Root Cause

The valued picking report assumes that all stock move lines have an associated currency coming from the sale order.

However, manually added move lines:
	•	are not linked to a sale order line
	•	do not have currency_id set
	•	still expose sale_price_subtotal as a Monetary field

This results in a QWeb rendering error.

Solution

Make the report rendering more robust by explicitly defining a fallback currency at QWeb level.

The currency is resolved in the following order:
	1.	move_line.currency_id
	2.	move_line.move_id.sale_line_id.currency_id
	3.	move_line.company_id.currency_id

This guarantees that:
	•	the report never crashes
	•	values remain unchanged
	•	the fix is limited to rendering logic only

Notes on Testing

This change only affects QWeb report rendering and does not modify business logic or data.

Given the scope and the complexity of testing QWeb rendering in CI, no automated test has been added, following existing precedent in this repository.