### PR TITLE
[18.0][FIX] stock_account_valuation_report: avoid field override

### DIFF
--- a/stock_account_valuation_report/models/product_product.py
+++ b/stock_account_valuation_report/models/product_product.py
@@ -19,7 +19,7 @@ class ProductProduct(models.Model):
     stock_fifo_real_time_aml_ids = fields.Many2many(
         "account.move.line", compute="_compute_inventory_value"
     )
-    stock_valuation_layer_ids = fields.Many2many(
+    valuation_layer_ids = fields.Many2many(
         "stock.valuation.layer", compute="_compute_inventory_value"
     )
     valuation_discrepancy = fields.Float(
@@ -142,9 +142,9 @@ class ProductProduct(models.Model):
             quantity, value, svl_ids = layer_values.get(product.id) or (0, 0, [])
             product.stock_value = value
             product.qty_at_date = quantity
-            product.stock_valuation_layer_ids = self.env[
-                "stock.valuation.layer"
-            ].browse(svl_ids)
+            product.valuation_layer_ids = self.env["stock.valuation.layer"].browse(
+                svl_ids
+            )
             if product.valuation == "real_time":
                 product.valuation_discrepancy = (
                     product.stock_value - product.account_value
@@ -183,7 +183,7 @@ class ProductProduct(models.Model):
             "stock_account.stock_valuation_layer_report_action"
         )
         action["domain"] = [
-            ("id", "in", self.stock_valuation_layer_ids.ids),
+            ("id", "in", self.valuation_layer_ids.ids),
         ]
         action["context"] = {}
         return action


### PR DESCRIPTION
The `stock_valuation_layer_ids` field was overriding a standard Odoo field (see [original definition](https://github.com/odoo/odoo/blob/fd42e8313bd70269d1150fb1dd162e56561a2bd8/addons/stock_account/models/product.py#L148)), changing its type, the store condition, and even the inverse relationship with the `stock.valuation.layer` model through the `product_id` field. 

These caused issues with computed field cache invalidation. Specifically, creating or writing new stock valuation layers no longer triggered automatic recomputation of dependent product fields such as `value_svl` and `quantity_svl`.

To fix this, we renamed the field instead of overriding the standard field. This avoids conflicts with dependency tracking and ensures cache invalidation works correctly. Because the field is originally computed and non-stored, there is no need to implement a migration script.