### PR TITLE
[17.0][FIX]stock_move_value_report: fix stock_move_line_value_report not printing stock move lines

### DIFF
--- a/stock_move_value_report/report/stock_move_line_value_report.xml
+++ b/stock_move_value_report/report/stock_move_line_value_report.xml
@@ -126,87 +126,27 @@
             <t t-call="web.external_layout">
                 <div class="page">
                     <h2 class="mb48">Selected operations cost value</h2>
-                    <t
-                        t-set="ml_from_pickings"
-                        t-value="move_lines_ids.filtered('move_id.picking_id')"
-                    />
-                    <t t-set="ml_from_inventories" />
-                    <t
-                        t-set="ml_from_scraps"
-                        t-value="move_lines_ids.filtered('move_id.scrapped')"
-                    />
-                    <!-- ML From Pickings -->
-                    <t t-if="ml_from_pickings">
-                        <t
-                            t-set="pickings"
-                            t-value="ml_from_pickings.mapped('move_id.picking_id')"
-                        />
-                        <t t-foreach="pickings" t-as="picking">
+                    <t t-foreach="move_lines_ids" t-as="move_line">
+                        <h4><span>[<t t-esc="move_line.date" />]</span> <t
+                                t-esc="move_line.reference"
+                            />: <t t-esc="move_line.location_id.name" /> &#8594; <t
+                                t-esc="move_line.location_dest_id.name"
+                            /></h4>
+                        <t t-call="stock_move_value_report.stock_move_lines_value">
+                            <t t-set="move_lines" t-value="move_line" />
                             <t
-                                t-set="picking_move_lines"
-                                t-value="ml_from_pickings.filtered(lambda x: x.picking_id == picking)"
+                                t-set="currency_id"
+                                t-value="move_line.company_id.currency_id"
                             />
-                            <h4><span>[<t t-esc="picking.date" />]</span> Picking <t
-                                    t-esc="picking.name"
-                                />: <t t-esc="picking.location_id.name" /> &#8594; <t
-                                    t-esc="picking.location_dest_id.name"
-                                /></h4>
-                            <t t-call="stock_move_value_report.stock_move_lines_value">
-                                <t t-set="move_lines" t-value="picking_move_lines" />
-                                <t
-                                    t-set="currency_id"
-                                    t-value="picking.company_id.currency_id"
-                                />
-                            </t>
-                            <t
-                                t-call="stock_move_value_report.stock_move_lines_value_total"
-                            >
-                                <t t-set="move_lines" t-value="picking_move_lines" />
-                                <t
-                                    t-set="currency_id"
-                                    t-value="picking.company_id.currency_id"
-                                />
-                            </t>
                         </t>
-                    </t>
-                    <!-- ML From Scraps -->
-                    <t t-if="ml_from_scraps">
                         <t
-                            t-set="scraps"
-                            t-value="move_lines_ids.mapped('move_id.scrap_id').filtered(lambda x: x in ml_from_scraps.mapped('move_id.scrap_id'))"
-                        />
-                        <t t-foreach="scraps" t-as="scrap">
-                            <t t-foreach="scrap.move_ids" t-as="scrap_move">
-                                <t
-                                    t-set="scrap_move_lines"
-                                    t-value="scrap_move.move_line_ids"
-                                />
-                                <h4><span>[<t
-                                            t-esc="scrap_move.date"
-                                        />]</span> Scrap <t t-esc="scrap.name" />: <t
-                                        t-esc="scrap.location_id.name"
-                                    /> &#8594; <t
-                                        t-esc="scrap.scrap_location_id.name"
-                                    /></h4>
-                                <t
-                                    t-call="stock_move_value_report.stock_move_lines_value"
-                                >
-                                    <t t-set="move_lines" t-value="scrap_move_lines" />
-                                    <t
-                                        t-set="currency_id"
-                                        t-value="res_company.currency_id"
-                                    />
-                                </t>
-                                <t
-                                    t-call="stock_move_value_report.stock_move_lines_value_total"
-                                >
-                                    <t t-set="move_lines" t-value="scrap_move_lines" />
-                                    <t
-                                        t-set="currency_id"
-                                        t-value="res_company.currency_id"
-                                    />
-                                </t>
-                            </t>
+                            t-call="stock_move_value_report.stock_move_lines_value_total"
+                        >
+                            <t t-set="move_lines" t-value="move_line" />
+                            <t
+                                t-set="currency_id"
+                                t-value="move_line.company_id.currency_id"
+                            />
                         </t>
                     </t>
                 </div>
@@ -222,8 +162,20 @@
                                     <td><strong
                                         >Total operations value balance</strong></td>
                                     <td class="text-end">
+                                        <t t-set="total" t-value="0" />
+                                        <t t-foreach="move_lines_ids" t-as="ml">
+                                            <t
+                                                t-foreach="ml.move_id.stock_valuation_layer_ids"
+                                                t-as="svl"
+                                            >
+                                                <t
+                                                    t-set="total"
+                                                    t-value="total + svl.value"
+                                                />
+                                            </t>
+                                        </t>
                                         <strong
-                                            t-esc="sum([x.move_id.price_unit * x.quantity for x in move_lines_ids])"
+                                            t-esc="total"
                                             t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                                         />
                                     </td>


### PR DESCRIPTION
Now the report prints all selected stock move lines, removing the picking and scrap filters and computing values directly from the related stock moves.