### PR TITLE
[18.0][FIX] stock_picking_report_valued: Change the call to the module of discount group

### DIFF
--- a/stock_picking_report_valued/report/stock_picking_report_valued.xml
+++ b/stock_picking_report_valued/report/stock_picking_report_valued.xml
@@ -13,7 +13,7 @@
                 <th class="text-end">
                     <strong>Unit Price</strong>
                 </th>
-                <th class="text-end" groups="product.group_discount_per_so_line">
+                <th class="text-end" groups="sale.group_discount_per_so_line">
                     <strong>Discount</strong>
                 </th>
                 <th class="text-end">
@@ -142,7 +142,7 @@
                 <td class="text-end">
                     <span t-field="move_line.sale_price_unit" />
                 </td>
-                <td class="text-end" groups="product.group_discount_per_so_line">
+                <td class="text-end" groups="sale.group_discount_per_so_line">
                     <span t-field="move_line.sale_discount" />
                 </td>
                 <td class="text-end">


### PR DESCRIPTION
**Description of the issue/feature:**

Fixes an issue in the stock_picking_report_valued module where the "Discount" column was not behaving correctly due to an invalid or incorrect security group reference.

Currently, the table header and data cells for the discount refer to product.group_discount_per_so_line. However, the standard Odoo group for sales order line discounts belongs to the sale module (sale.group_discount_per_so_line). This prevents the discount column from being displayed correctly for users with the right permissions, or could potentially raise an External ID error during view rendering/parsing.

This PR fixes the issue by updating the groups attribute in the report's XML view to point to the correct sale module group.

**Steps to reproduce:**

   1. Install the stock_picking_report_valued module.

   2. Ensure the "Discount on sales order lines" feature is enabled in the Sales settings.

   3. Create a Sales Order with a discount on its lines and confirm it to generate a delivery (picking).

   4. Print the Valued Picking Report.

**Current behavior:**

The discount column does not render for the user (because the product.group_discount_per_so_line group either does not exist or the user is not part of it), or an evaluation error occurs due to the wrong External ID.

**Expected behavior:**

The discount column is displayed correctly in the report for any user who belongs to the standard sale.group_discount_per_so_line group.