### PR TITLE
[17.0][FIX] stock_picking_report_valued: Respect global tax rounding method

### DIFF
--- a/stock_picking_report_valued/models/stock_picking.py
+++ b/stock_picking_report_valued/models/stock_picking.py
@@ -69,16 +69,12 @@ class StockPicking(models.Model):
                     tax_lines_data.append(tax_line_dict)
 
                 if tax_lines_data:
-                    tax_results = pick.env["account.tax"]._compute_taxes(
-                        tax_lines_data
-                    )
+                    tax_results = pick.env["account.tax"]._compute_taxes(tax_lines_data)
                     totals = tax_results["totals"]
                     amount_untaxed = totals.get(pick.currency_id, {}).get(
                         "amount_untaxed", 0.0
                     )
-                    amount_tax = totals.get(pick.currency_id, {}).get(
-                        "amount_tax", 0.0
-                    )
+                    amount_tax = totals.get(pick.currency_id, {}).get("amount_tax", 0.0)
                 else:
                     amount_untaxed = amount_tax = 0.0
             else:

--- a/stock_picking_report_valued/models/stock_picking.py
+++ b/stock_picking_report_valued/models/stock_picking.py
@@ -41,10 +41,51 @@ class StockPicking(models.Model):
         records...).
         """
         for pick in self:
-            amount_untaxed = amount_tax = 0.0
-            for line in pick.move_line_ids:
-                amount_untaxed += line.sale_price_subtotal
-                amount_tax += line.sale_price_tax
+            pick = pick.with_company(pick.company_id)
+            move_lines = pick.move_line_ids.filtered(lambda x: x.sale_line)
+
+            if pick.company_id.tax_calculation_rounding_method == "round_globally":
+                # With global rounding, we need to use the same method as sale.order
+                # to calculate taxes on all lines together, not sum line by line
+                tax_lines_data = []
+                for line in move_lines:
+                    valued_line = line.sale_line
+                    quantity = line._get_report_valued_quantity()
+                    different_uom = valued_line.product_uom != line.product_uom_id
+                    different_qty = float_compare(
+                        quantity,
+                        valued_line.product_uom_qty,
+                        precision_rounding=line.product_uom_id.rounding,
+                    )
+                    if different_uom or different_qty:
+                        # Create virtual sale line with move line quantity
+                        valued_line.mapped("tax_id")  # Force cache
+                        sol_vals = valued_line._convert_to_write(valued_line._cache)
+                        sol_vals["product_uom_qty"] = quantity
+                        sol_vals.pop("price_subtotal", None)
+                        valued_line = valued_line.new(sol_vals)
+
+                    tax_line_dict = valued_line._convert_to_tax_base_line_dict()
+                    tax_lines_data.append(tax_line_dict)
+
+                if tax_lines_data:
+                    tax_results = pick.env["account.tax"]._compute_taxes(
+                        tax_lines_data
+                    )
+                    totals = tax_results["totals"]
+                    amount_untaxed = totals.get(pick.currency_id, {}).get(
+                        "amount_untaxed", 0.0
+                    )
+                    amount_tax = totals.get(pick.currency_id, {}).get(
+                        "amount_tax", 0.0
+                    )
+                else:
+                    amount_untaxed = amount_tax = 0.0
+            else:
+                # With round_per_line, sum the tax from each line (current behavior)
+                amount_untaxed = sum(move_lines.mapped("sale_price_subtotal"))
+                amount_tax = sum(move_lines.mapped("sale_price_tax"))
+
             pick.update(
                 {
                     "amount_untaxed": amount_untaxed,

--- a/stock_picking_report_valued/tests/test_stock_picking_valued.py
+++ b/stock_picking_report_valued/tests/test_stock_picking_valued.py
@@ -182,3 +182,41 @@ class TestStockPickingValued(common.TransactionCase):
         finally:
             # Restore original method
             StockPicking._get_report_valued_total_amount = original_method
+
+    def test_08_partial_delivery_with_round_globally(self):
+        """
+        Test partial delivery (different quantity) with global tax rounding.
+        This tests the code path that creates a virtual sale line with
+        different quantity when round_globally is active.
+        """
+        self.sale_order.company_id.tax_calculation_rounding_method = "round_globally"
+        self.sale_order.action_confirm()
+        self.assertTrue(len(self.sale_order.picking_ids))
+        picking = self.sale_order.picking_ids[0]
+        picking.action_assign()
+        # Change quantity to trigger the different_qty code path
+        picking.move_line_ids.quantity = 0.5
+        # Force recompute
+        picking.invalidate_recordset(["amount_untaxed", "amount_tax", "amount_total"])
+        # With 0.5 quantity: 100 * 0.5 = 50, tax = 50 * 0.15 = 7.5
+        self.assertEqual(picking.amount_untaxed, 50.0)
+        self.assertEqual(picking.amount_tax, 7.5)
+        self.assertEqual(picking.amount_total, 57.5)
+
+    def test_09_empty_picking_with_round_globally(self):
+        """
+        Test picking without sale lines with global tax rounding.
+        This tests the code path when tax_lines_data is empty.
+        """
+        self.sale_order.company_id.tax_calculation_rounding_method = "round_globally"
+        self.sale_order.action_confirm()
+        picking = self.sale_order.picking_ids[0]
+        picking.action_assign()
+        # Unreserve to clear move_line_ids with sale_line
+        picking.do_unreserve()
+        # Force recompute
+        picking.invalidate_recordset(["amount_untaxed", "amount_tax", "amount_total"])
+        # Should be 0.0 when no lines
+        self.assertEqual(picking.amount_untaxed, 0.0)
+        self.assertEqual(picking.amount_tax, 0.0)
+        self.assertEqual(picking.amount_total, 0.0)


### PR DESCRIPTION
Problem:

The module was calculating picking tax amounts by always summing the 
sale_price_tax field from each move line, regardless of the company's 
tax_calculation_rounding_method setting. This caused discrepancies with 
the related sale order when using global tax rounding (round_globally).

When round_globally is configured, sale.order calculates taxes on the 
total base amount using account.tax._compute_taxes(), but the picking 
was summing individual line taxes, leading to rounding differences.

Example:
I've recreated the example in Runboat. 
https://www.awesomescreenshot.com/video/51310632?key=f816ff453f1917171dd799d033108b69
Sorry for my poor pronunciation

With Spanish accounting enabled, line discounts and global rounding selected.
In the Sale Order:
<img width="1192" height="773" alt="image" src="https://github.com/user-attachments/assets/f08faba3-36c3-484b-b7ec-d4e5f77006f3" />

In the Delivery Slip Valued
<img width="735" height="620" alt="image" src="https://github.com/user-attachments/assets/38f06e41-70fb-44d6-b64a-f77f568c33ed" />
 

Solution:

Modified StockPicking._compute_amount_all() to respect the company's 
tax rounding configuration:

- When tax_calculation_rounding_method is "round_globally": Uses the 
  same method as sale.order by calling account.tax._compute_taxes() 
  with all lines together, ensuring taxes match the sale order exactly.

- When tax_calculation_rounding_method is "round_per_line": Keeps the 
  original behavior of summing sale_price_tax from each line.

This ensures picking amounts always match the related sale order totals, 
regardless of the tax rounding method configured.