### PR TITLE
[17.0][FIX] stock_picking_report_custom_description: avoid duplicated references

### DIFF
--- a/stock_picking_report_custom_description/README.rst
+++ b/stock_picking_report_custom_description/README.rst
@@ -70,13 +70,13 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Carlos Dauden
-  - Sergio Teruel
-  - Ernesto Tejeda
-  - Pilar Vargas
-  - Carolina Fernandez
+   -  Carlos Dauden
+   -  Sergio Teruel
+   -  Ernesto Tejeda
+   -  Pilar Vargas
+   -  Carolina Fernandez
 
 Maintainers
 -----------

--- a/stock_picking_report_custom_description/__manifest__.py
+++ b/stock_picking_report_custom_description/__manifest__.py
@@ -17,5 +17,7 @@
     "depends": [
         "sale_stock",
     ],
-    "data": [],
+    "data": [
+        "report/report_deliveryslip.xml",
+    ],
 }

--- a/stock_picking_report_custom_description/report/report_deliveryslip.xml
+++ b/stock_picking_report_custom_description/report/report_deliveryslip.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
+        <!-- Avoid duplicated product references when the picking description already
+        includes the product name. -->
+        <xpath expr="//span[@t-field='move.product_id']/.." position="attributes">
+            <attribute name="class">d-none</attribute>
+        </xpath>
+        <xpath expr="//span[@t-field='move.product_id']/.." position="after">
+            <td>
+                <t
+                    t-if="not move.description_picking or move.product_id.name not in move.description_picking"
+                >
+                    <span t-field="move.product_id" />
+                </t>
+                <p t-if="move.description_picking">
+                    <span t-field="move.description_picking" />
+                </p>
+            </td>
+        </xpath>
+        <xpath expr="//span[@t-field='bo_line.product_id']/.." position="attributes">
+            <attribute name="class">d-none</attribute>
+        </xpath>
+        <xpath expr="//span[@t-field='bo_line.product_id']/.." position="after">
+            <td>
+                <t
+                    t-if="not bo_line.description_picking or bo_line.product_id.name not in bo_line.description_picking"
+                >
+                    <span t-field="bo_line.product_id" />
+                </t>
+                <p t-if="bo_line.description_picking">
+                    <span t-field="bo_line.description_picking" />
+                </p>
+            </td>
+        </xpath>
+    </template>
+    <template
+        id="stock_report_delivery_has_serial_move_line"
+        inherit_id="stock.stock_report_delivery_has_serial_move_line"
+    >
+        <!-- Avoid duplicated product references when the picking description already
+        includes the product name. -->
+        <xpath expr="//span[@t-field='move_line.product_id']/.." position="attributes">
+            <attribute name="class">d-none</attribute>
+        </xpath>
+        <xpath expr="//span[@t-field='move_line.product_id']/.." position="after">
+            <td>
+                <t t-if="not description and description != ''">
+                    <t
+                        t-set="description"
+                        t-value="move_line.move_id.description_picking"
+                    />
+                </t>
+                <t
+                    t-if="not description or move_line.product_id.name not in description"
+                >
+                    <span t-field="move_line.product_id" />
+                </t>
+                <p t-if="description != ''">
+                    <span t-esc="description" />
+                </p>
+            </td>
+        </xpath>
+    </template>
+    <template
+        id="stock_report_delivery_aggregated_move_lines"
+        inherit_id="stock.stock_report_delivery_aggregated_move_lines"
+    >
+        <!-- Avoid duplicated product references when the picking description already
+        includes the product name. -->
+        <xpath
+            expr="//td/span[@t-esc=&quot;aggregated_lines[line][&apos;name&apos;]&quot;]"
+            position="attributes"
+        >
+            <attribute
+                name="t-if"
+            >not aggregated_lines[line]['description'] or aggregated_lines[line]['product'].name not in aggregated_lines[line]['description']</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Avoid printing the product when the picking description already contains it.

Some modules or manual edits only change the reference, not the product name, causing duplicated information in delivery slips.

@Tecnativa TT61271

Before:
<img width="1184" height="286" alt="image" src="https://github.com/user-attachments/assets/5587989c-f92b-4143-aa60-6aaf78d47668" />


After:
<img width="1184" height="286" alt="image" src="https://github.com/user-attachments/assets/f565bfce-c82f-4358-b291-998da9f11a8d" />


@pedrobaeza @carlos-lopez-tecnativa please review