### PR TITLE
[17.0][FIX] stock_picking_report_custom_description: always transfer sale line description

### DIFF
--- a/stock_picking_report_custom_description/models/stock_rule.py
+++ b/stock_picking_report_custom_description/models/stock_rule.py
@@ -36,10 +36,6 @@ class StockRule(models.Model):
             description_picking = line.name
             if description_picking.startswith(pattern):
                 description_picking = description_picking.replace(pattern, "")
-            if (
-                description_picking
-                and description_picking != line.product_id.display_name
-            ):
-                res["description_picking"] = description_picking
+            res["description_picking"] = description_picking
             res["name"] = line.name
         return res


### PR DESCRIPTION
The module is intended to transfer the sale order line description to the picking description.

However, when the sale line description matched the product display name, the description_picking value was not updated, because the assignment was skipped by the condition checking that both values were different.

As a result, the stock move kept the default description generated by Odoo, which could omit the product reference.

Keep the existing logic that trims the product display name prefix when an additional sale description is present, but always assign the resulting description to the picking.

@Tecnativa TT61271

@pedrobaeza @victoralmau please review