### PR TITLE
[16.0][IMP] stock_average_daily_sale: optimize the query to compute the ave…

### DIFF
--- a/stock_average_daily_sale/models/stock_average_daily_sale.py
+++ b/stock_average_daily_sale/models/stock_average_daily_sale.py
@@ -213,32 +213,83 @@ class StockAverageDailySale(models.Model):
                     WHERE
                         stock_average_daily_sale_config.active = True
                 ),
-                -- Collect all moves from the config location to outside that location
+                -- Collect max and min date on all moves to avoid to collect all moves outside the observed scopes
+                cfg_bounds AS (
+                    SELECT
+                        min(date_from) AS min_date,
+                        max(date_to) AS max_date
+                    FROM cfg
+                ),
+                -- Collect products
+                cfg_products AS (
+                    SELECT
+                        cfg.id AS config_id,
+                        pp.id AS product_id
+                    FROM
+                        cfg
+                    JOIN product_template pt
+                        ON cfg.abc_classification_level = COALESCE(pt.abc_storage, 'c')
+                    JOIN product_product pp
+                        ON pt.id = pp.product_tmpl_id
+                ),
+                -- Collect config locations
+                cfg_locations AS (
+                    SELECT
+                        cfg.id AS config_id,
+                        sl.id AS location_id
+                    FROM
+                        cfg
+                    JOIN
+                        stock_location sl
+                        ON sl.parent_path LIKE cfg.location_parent_path || '%%'
+                ),
+                -- Prefilter moves used to compute the consumption in order to avoid to process all moves of the system.
+                -- Only moves with a date between the min and max bounds of the different configs are kept
+                filtered_moves AS (
+                    SELECT
+                        sm.id,
+                        sm.product_id,
+                        sm.location_id,
+                        sm.location_dest_id,
+                        sm.product_uom_qty,
+                        sm.date,
+                        sm.date::date AS day
+                    FROM
+                        stock_move sm
+                    CROSS JOIN
+                        cfg_bounds cb
+                    WHERE
+                        sm.state = 'done'
+                        AND sm.product_uom_qty > 0
+                        AND sm.date >= cb.min_date
+                        AND sm.date < cb.max_date + interval '1 day'
+                        AND EXISTS (SELECT 1 FROM cfg_products cp WHERE cp.product_id = sm.product_id)
+                ),
+                -- Collect moves from the config location to outside that location
                 consumption AS (
                     SELECT
-                        sm.product_id,
-                        sm.product_uom_qty,
+                        fm.product_id,
+                        fm.product_uom_qty,
                         cfg.id AS config_id,
-                        sm.date::date AS day
-                    FROM stock_move sm
-                        JOIN stock_location sl_src ON sm.location_id = sl_src.id
-                        JOIN stock_location sl_dest ON sm.location_dest_id = sl_dest.id
-                        JOIN product_product pp ON pp.id = sm.product_id
-                        JOIN product_template pt ON pp.product_tmpl_id = pt.id
-                        CROSS JOIN LATERAL (
-                            SElECT * FROM cfg
-                            WHERE cfg.abc_classification_level = COALESCE(pt.abc_storage, 'c')
-                            AND sl_src.parent_path ilike concat(cfg.location_parent_path, '%%')
-                            AND sl_dest.parent_path not ilike concat(cfg.location_parent_path, '%%')
-                            -- as date is datetime and date_to is a date, we need to add 1 day to include date_to day
-                            AND sm.date BETWEEN cfg.date_from AND (cfg.date_to + '1 day'::interval)
-                            -- Consumption on excluded days are included
-                            -- AND (NOT cfg.exclude_weekends OR EXTRACT(ISODOW FROM sm.date) NOT IN (6,7))
-                        ) AS cfg
-                    WHERE
-                        sm.state = 'done' AND sm.product_uom_qty > 0
-                        -- exclude inventory loss
+                        fm.day
+                    FROM
+                        filtered_moves fm
+                    JOIN stock_location sl_dest
+                        ON sl_dest.id = fm.location_dest_id
                         AND sl_dest.usage != 'inventory'
+                    JOIN cfg_products cp
+                        ON cp.product_id = fm.product_id
+                    JOIN cfg
+                        ON cfg.id = cp.config_id
+                    JOIN stock_location sl_src
+                        ON sl_src.id = fm.location_id
+                    WHERE
+                        fm.date >= cfg.date_from
+                        AND fm.date < cfg.date_to + interval '1 day'
+                        -- source inside hierarchy
+                        AND sl_src.parent_path LIKE cfg.location_parent_path || '%%'
+                        -- destination outside hierarchy
+                        AND sl_dest.parent_path NOT LIKE cfg.location_parent_path || '%%'
                 ),
                 -- Aggregate on a daily basis
                 daily_consumption AS (


### PR DESCRIPTION
…rage daily sales

Before this commit, the query to compute the average daily sales took into account all the stock moves of the company to compute the daily consumption, and then filter the result by applying the date bounds for each configuration. This was inefficient as it processed a lot of irrelevant data. Now, the query pre-filters the stock moves by applying the minimum date_from and maximum date_to of all the configurations to the stock moves to compute the consumption, and then apply the date bounds for each configuration. This results in a significant performance improvement and ensure no slow degradation of the performance when the number of stock moves increases.