### PR TITLE
[19.0][FIX] stock_picking_report_valued: remove old field use

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -43,7 +43,7 @@ class StockMoveLine(models.Model):
     )
 
     def _get_report_valued_quantity(self):
-        return self.quantity or self.reserved_qty
+        return self.quantity
 
     def _compute_sale_order_line_fields(self):
         """This is computed with sudo for avoiding problems if you don't have


### PR DESCRIPTION
`reserved_qty` does no longer exist in v19. `quantity` is now a computed field that shows either reserved or validated quantity.

Fixes https://github.com/OCA/stock-logistics-reporting/issues/501