### PR TITLE
[19.0][FIX] stock_product_demand_info: exclude today from demand periods

### DIFF
--- a/stock_product_demand_info/models/product_product.py
+++ b/stock_product_demand_info/models/product_product.py
@@ -88,6 +88,9 @@ class ProductProduct(models.Model):
                 ("product_id", "in", product_ids),
                 ("date", ">=", period.start_expression),
                 ("date", "<=", period.end_expression),
+                # Demand history is based on completed days only,
+                # so we exclude moves of the current day (even if they are done).
+                ("date", "<", "today"),
                 ("state", "in", moves_states),
                 ("product_qty", ">", 0),
             ]

--- a/stock_product_demand_info/tests/common.py
+++ b/stock_product_demand_info/tests/common.py
@@ -22,6 +22,7 @@ class StockProductDemandInfoCommon(TransactionCase):
             "stock_product_demand_info.period_last_30_days"
         )
         cls.period_last_year = cls.env.ref("stock_product_demand_info.period_last_year")
+        cls.period_ytd = cls.env.ref("stock_product_demand_info.period_ytd")
         cls.period_same_month_last_year = cls.env.ref(
             "stock_product_demand_info.period_same_month_last_year"
         )

--- a/stock_product_demand_info/tests/test_product_demand_period.py
+++ b/stock_product_demand_info/tests/test_product_demand_period.py
@@ -3,6 +3,9 @@
 
 from datetime import timedelta
 
+from freezegun import freeze_time
+
+from odoo import fields
 from odoo.exceptions import UserError
 from odoo.fields import Command
 
@@ -66,6 +69,28 @@ class TestProductDemandPeriod(StockProductDemandInfoCommon):
         self.assertIn(key, self.orderpoint.demand_period_info)
         self.assertEqual(self.orderpoint.demand_period_info[key]["value"], 7.0)
         self.assertEqual(self.orderpoint.demand_period_info[key]["name"], "Last 7 days")
+
+    @freeze_time("2026-05-28 12:00:00")
+    def test_ytd_excludes_today(self):
+        """Test YTD demand excludes outgoing moves dated today."""
+        today = fields.Date.today()
+        self.period_ytd.active = True
+        self._create_outgoing_move(self.product, today - timedelta(days=1), 2000.0)
+        self._create_outgoing_move(self.product, today, 800.0)
+        self.product.invalidate_recordset(["demand_period_info"])
+        key = str(self.period_ytd.id)
+        self.assertEqual(self.product.demand_period_info[key]["value"], 2000.0)
+
+    @freeze_time("2026-05-28 12:00:00")
+    def test_orderpoint_ytd_excludes_today(self):
+        """Test orderpoint YTD demand excludes outgoing moves dated today."""
+        today = fields.Date.today()
+        self.period_ytd.active = True
+        self._create_outgoing_move(self.product, today - timedelta(days=1), 2000.0)
+        self._create_outgoing_move(self.product, today, 800.0)
+        self.orderpoint.invalidate_recordset(["demand_period_info"])
+        key = str(self.period_ytd.id)
+        self.assertEqual(self.orderpoint.demand_period_info[key]["value"], 2000.0)
 
     def test_demand_no_active_periods(self):
         """With no active periods, demand_period_info is empty."""


### PR DESCRIPTION
Fixes the replenishment “Demand by period” so historical demand excludes stock moves of today.

Real issue case: when checking a product in the replenishment view, validating an outgoing move today immediately increased the “Year to date” demand value.
This made YTD look like completed historical demand had changed during the day, while today’s demand is still in progress.
The demand period domain now caps history at `date < today`.

Hello @ivantodorovich , can you pls take a look?