### PR TITLE
[FIX] stock_picking_report_valued: set valued_picking default to False

### DIFF
--- a/stock_picking_report_valued/models/res_partner.py
+++ b/stock_picking_report_valued/models/res_partner.py
@@ -10,5 +10,5 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     valued_picking = fields.Boolean(
-        default=True, help="You can select which partners have valued pickings"
+        default=False, help="You can select which partners have valued pickings"
     )

--- a/stock_picking_report_valued/tests/test_stock_picking_valued.py
+++ b/stock_picking_report_valued/tests/test_stock_picking_valued.py
@@ -34,7 +34,9 @@ class TestStockPickingValued(common.TransactionCase):
                 "taxes_id": [(6, 0, cls.tax.ids)],
             }
         )
-        cls.partner = cls.env["res.partner"].create({"name": "Mr. Odoo"})
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "Mr. Odoo", "valued_picking": True}
+        )
         cls.sale_order = cls.env["sale.order"].create(
             {
                 "partner_id": cls.partner.id,


### PR DESCRIPTION
Partners should not have valued pickings enabled by default when the module is installed, as this causes delivery slips to print with prices visible without any explicit configuration.