### PR TITLE
[17.0][IMP] stock_picking_report_valued: add sale.order.line values on sol_vals if sale_line._cache is empty.

### DIFF
--- a/stock_picking_report_valued/models/stock_move_line.py
+++ b/stock_picking_report_valued/models/stock_move_line.py
@@ -75,8 +75,18 @@ class StockMoveLine(models.Model):
                 # Create virtual sale line with stock move line quantity
                 sol_vals = line.sale_line._convert_to_write(line.sale_line._cache)
                 sol_vals["product_uom_qty"] = quantity
+                if not sol_vals.get("product_id", None):
+                    sol_vals.update(
+                        {
+                            "product_id": line.sale_line.product_id.id,
+                            "order_id": line.sale_line.order_id.id,
+                            "discount": line.sale_line.discount,
+                            "price_unit": line.sale_line.price_unit,
+                        }
+                    )
                 sol_vals.pop("price_subtotal", None)
                 valued_line = line.sale_line.new(sol_vals)
+                valued_line._compute_amount()
             line.update(
                 {
                     "sale_tax_description": ", ".join(


### PR DESCRIPTION
@binhexTeam

This change fixes an issue in stock_picking_report_valued when rendering a valued picking report during email sending.

In this flow, sale_line._cache may be incomplete, so _convert_to_write(sale_line._cache) can return sol_vals without the minimum required sale.order.line fields (for example: product_id, order_id, discount, price_unit).
When that happens, creating the virtual line and triggering amount/tax computation can fail in order_line._compute_all().

**What was changed**
A fallback was added to complete sol_vals whenever key fields are missing:

product_id
order_id
discount
price_unit

Additionally, after creating the virtual line with new(sol_vals), _compute_amount() is explicitly called to ensure amounts and taxes are properly recomputed with complete values.

**Expected result**
Sending the email no longer breaks valued picking computation when sale.order.line cache is incomplete.
The valued report keeps consistent subtotal and tax values.