### PR TITLE
[18.0][FIX] stock_picking_comment_template: improve action settings

### DIFF
--- a/stock_picking_comment_template/views/base_comment_template_view.xml
+++ b/stock_picking_comment_template/views/base_comment_template_view.xml
@@ -5,10 +5,8 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.comment.template</field>
         <field name="view_mode">list,form</field>
-        <field
-            name="domain"
-            eval="[('model_ids', 'in', [ref('stock.model_stock_picking')])]"
-        />
+        <field name="domain" eval="[('model_ids', '=', 'stock.picking')]" />
+        <field name="context" eval="{'default_models': 'stock.picking'}" />
         <field
             name="view_id"
             ref="base_comment_template.view_base_comment_template_tree"


### PR DESCRIPTION
Ẅith these changes:

- Comments are shown in document comments pickings menu
- When a new comment is created, default model value is set automatically.